### PR TITLE
feat(agent): add low-level snapshot API for point-in-time state capture

### DIFF
--- a/SNAPSHOT.md
+++ b/SNAPSHOT.md
@@ -102,22 +102,6 @@ The intent is that anything stored or restored by session-management would be st
 - **`type`, `version`, `timestamp`, and `data`** — Strands-owned. These fields are managed internally and should be treated as opaque. The format of `data` is subject to change; do not modify or depend on its structure.
 - **Serialization** — Strands guarantees that all Strands-owned fields will only contain JSON-serializable values.
 
-### FileSystemPersister
-
-A `FileSystemPersister` helper class is provided for basic persistence:
-
-```python
-from strands.agent.snapshot import FileSystemPersister
-
-# Save a snapshot
-persister = FileSystemPersister(path="checkpoints/snapshot.json")
-persister.save(agent.take_snapshot(include="session"))
-
-# Load a snapshot
-snapshot = persister.load()
-agent.load_snapshot(snapshot)
-```
-
 ### Future Concerns
 
 - Snapshotting for MultiAgent constructs - Snapshot is designed in a way that the snapshot could be reused for multi-agent with a similar api
@@ -157,18 +141,22 @@ later_agent.load_snapshot(snapshot)
 
 ### Persisting Snapshots
 
+Snapshots are plain JSON-serializable dicts, so persistence is straightforward. The SDK includes a `FileSystemPersister` as a reference implementation, but this is provided as an example pattern rather than a production-ready utility. Applications should implement their own persistence strategy based on their storage requirements.
+
 ```python
-from strands.agent.snapshot import FileSystemPersister
+import json
 
 agent = Agent(tools=[tool1, tool2])
 agent("Remember that my favorite color is orange.")
 
 # Save to file
 snapshot = agent.take_snapshot(include="session", app_data={"user_id": "123"})
-FileSystemPersister("snapshot.json").save(snapshot)
+with open("snapshot.json", "w") as f:
+    json.dump(snapshot, f)
 
 # Later, restore from file
-snapshot = FileSystemPersister("snapshot.json").load()
+with open("snapshot.json") as f:
+    snapshot = json.load(f)
 
 agent = Agent(tools=[tool1, tool2])
 agent.load_snapshot(snapshot)

--- a/SNAPSHOT.md
+++ b/SNAPSHOT.md
@@ -1,0 +1,174 @@
+# Design Doc: Low-Level Snapshot API
+
+**Status**: Proposed
+
+**Date**: 2026-01-28
+
+**Issue**: https://github.com/strands-agents/sdk-python/issues/1138
+
+## Motivation
+
+Today, developers who want to manually snapshot and restore agent state can *almost* do so by saving and loading these properties directly:
+
+- `Agent.messages` — the conversation history
+- `Agent.state` — custom application state
+- `Agent._interrupt_state` — internal state for interrupt handling
+- Conversation manager internal state — state held by the conversation manager (e.g., sliding window position)
+
+However, this approach is fragile: it requires knowledge of internal implementation details, and the set of properties may change between versions. This proposal introduces a stable, convenient API to accomplish the same thing without relying on internals.
+
+**This API does not change agent behavior** — it simply provides a clean way to serialize and restore the existing state that already exists on the agent.
+
+## Context
+
+Developers need a way to preserve and restore the exact state of an agent at a specific point in time. The existing SessionManagement doesn't address this:
+
+- SessionManager works in the background, incrementally recording messages rather than full state. This means it's not possible to restore to arbitrary points in time.
+- After a message is saved, there is no way to modify it and have it recorded in session-management, preventing more advance context-management strategies while being able to pause & restore agents.
+- There is no way to proactively trigger session-management (e.g., after modifying `agent.messages` or `agent.state` directly)
+
+## Decision
+
+Add a low-level, explicit snapshot API as an alternative to automatic session-management. This enables preserving the exact state of an agent at a specific point and restoring it later — useful for evaluation frameworks, custom session management, and checkpoint/restore workflows.
+
+### API Changes
+
+```python
+class Snapshot(TypedDict):
+    type: str              # the type of data stored (e.g., "agent")
+    state: dict[str, Any]  # opaque; do not modify — format subject to change
+    metadata: dict         # user-provided data to be stored with the snapshot
+
+class Agent:
+    def save_snapshot(self, metadata: dict | None = None) -> Snapshot:
+        """Capture the current agent state as a snapshot."""
+        ...
+
+    def load_snapshot(self, snapshot: Snapshot) -> None:
+        """Restore agent state from a snapshot."""
+        ...
+```
+
+### Behavior
+
+Snapshots capture **agent state** (data), not **runtime behavior** (code):
+
+- **Agent State** — Data persisted as part of session-management: conversation messages, context, and other JSON-serializable data. This is what snapshots save and restore.
+- **Runtime Behavior** — Configuration that defines how the agent operates: model, tools, ConversationManager, etc. These are *not* included in snapshots and must be set separately when creating or restoring an agent.
+
+The intent is that anything stored or restored by session-management would be stored in a snapshot — so this proposal is *not* documenting or changing what is persisted, but rather providing an explicit way to do what session-management does automatically.
+
+### Contract
+
+- **`metadata`** — Application-owned. Strands does not read, modify, or manage this field. Use it to store checkpoint labels, timestamps, or any application-specific data without the need for a separate/standalone object/datastore.
+- **`type` and `state`** — Strands-owned. These fields are managed internally and should be treated as opaque. The format of `state` is subject to change; do not modify or depend on its structure.
+- **Serialization** — Strands guarantees that `type` and `state` will only contain JSON-serializable values.
+
+### Future Concerns
+
+- Snapshotting for MultiAgent constructs - Snapshot is designed in a way that the snapshot could be reused for multi-agent with a similar api
+- Providing a storage API for snapshot CRUD operations (save to disk, database, etc.)
+- Providing APIs to customize serialization formats
+
+## Developer Experience
+
+### Evaluations via Rewind and Replay
+
+```python
+agent = Agent(tools=[tool1, tool2])
+snapshot = agent.save_snapshot()
+
+result1 = agent("What is the weather?")
+
+# ...
+
+agent2 = Agent(tools=[tool3, tool4])
+agent2.load_snapshot(snapshot)
+result2 = agent2("What is the weather?")
+# ... 
+# Human/manual evaluation if one outcome was better than the other
+# ...
+```
+
+### Advanced Context Management
+
+```python
+agent = Agent(conversation_manager=CompactingConversationManager())
+snapshot = agent.save_snapshot(metadata={"checkpoint": "before_long_task"})
+
+# ... later ...
+later_agent = Agent(conversation_manager=CompactingConversationManager())
+later_agent.load_snapshot(snapshot)
+```
+
+### Persisting Snapshots
+
+```python
+import json
+
+agent = Agent(tools=[tool1, tool2])
+agent("Remember that my favorite color is orange.")
+
+# Save to file
+snapshot = agent.save_snapshot(metadata={"user_id": "123"})
+with open("snapshot.json", "w") as f:
+    json.dump(snapshot, f)
+
+# Later, restore from file
+with open("snapshot.json", "r") as f:
+    snapshot: Snapshot = json.load(f)
+
+agent = Agent(tools=[tool1, tool2])
+agent.load_snapshot(snapshot)
+agent("What is my favorite color?")  # "Your favorite color is orange."
+```
+
+### Edge cases
+
+Restoring runtime behavior (e.g., tools) is explicitly not supported:
+
+```python
+agent1 = Agent(tools=[tool1, tool2])
+snapshot = agent1.save_snapshot()
+agent_no = Agent(snapshot)  # tools are NOT restored
+```
+
+## Up for Debate
+
+### What state should be included in a snapshot?
+
+The current proposal includes:
+
+- **messages** — conversation history
+- **interrupt state** — internal state for paused/resumed interrupts
+- **agent state** — custom application state (`agent.state`)
+- **conversation manager state** — internal state of the conversation manager (but not the conversation manager itself)
+
+This draws a distinction between "evolving state" (data that changes as the agent runs) and "agent definition" (configuration that defines what the agent *is*):
+
+| Evolving State (snapshotted) | Agent Definition (not snapshotted) |
+|------------------------------|-----------------------------------|
+| messages | system_prompt |
+| interrupt state | tools |
+| agent state | model |
+| conversation manager state | conversation_manager |
+
+Further justification: these three properties are also what SessionManagement persists today, so this API aligns with existing behavior.
+
+**Open question:** Is this the right boundary? Are there other properties that should be considered "evolving state"?
+
+## Consequences
+
+**Easier:**
+- Building evaluation frameworks with rewind/replay capabilities
+- Implementing custom session management strategies
+- Creating checkpoints during long-running agent tasks
+- Cloning agents (load the same snapshot into multiple agent instances)
+- Resetting agents to a known state (we do this manually for Graphs)
+
+**More difficult:**
+- N/A — this is an additive API
+
+## Willingness to Implement
+
+Yes

--- a/SNAPSHOT.md
+++ b/SNAPSHOT.md
@@ -10,7 +10,6 @@
 
 - [x] On-demand state capture — Developers can explicitly capture agent state at any point, independent of automatic session management.
 - [ ] Foundation for session management — Snapshots provide a primitive that session managers can use internally, enabling alternative persistence strategies beyond incremental message recording.
-- [x] Extensibility via hooks — Plugins and hook providers can contribute additional data to snapshots, allowing custom state to be captured and restored alongside core agent state.
 - [x] Configurable scope — Developers control which properties are included in a snapshot, enabling use cases that require only a subset of state (e.g., messages without interrupt state).
 
 ## Motivation
@@ -41,7 +40,10 @@ Add a low-level, explicit snapshot API as an alternative to automatic session-ma
 ### API
 
 ```python
-from strands.agent import Snapshotter
+from typing import Literal
+
+# Named preset for include parameter
+SnapshotPreset = Literal["session"]
 
 class Snapshot(TypedDict):
     type: str                # the type of data stored (e.g., "agent"). Strands-owned.
@@ -50,16 +52,8 @@ class Snapshot(TypedDict):
     data: dict[str, Any]     # opaque; do not modify — format subject to change. Strands-owned.
     app_data: dict[str, Any] # application-owned data to store with the snapshot
 
-class Snapshotter:
-    def __init__(
-        self,
-        include: SnapshotPreset | list[str] | None = None,
-        exclude: list[str] | None = None,
-    ) -> None:
-        """Initialize with default include/exclude settings."""
-        ...
-
-    def take(
+class Agent:
+    def take_snapshot(
         self,
         app_data: dict[str, Any] | None = None,
         include: SnapshotPreset | list[str] | None = None,
@@ -68,29 +62,9 @@ class Snapshotter:
         """Capture the current agent state as a snapshot."""
         ...
 
-    async def take_async(
-        self,
-        app_data: dict[str, Any] | None = None,
-        include: SnapshotPreset | list[str] | None = None,
-        exclude: list[str] | None = None,
-    ) -> Snapshot:
-        """Capture the current agent state as a snapshot (async)."""
-        ...
-
-    def load(self, snapshot: Snapshot) -> None:
+    def load_snapshot(self, snapshot: Snapshot) -> None:
         """Restore agent state from a snapshot."""
         ...
-
-class Agent:
-    def __init__(
-        self,
-        ...,
-        snapshots: Snapshotter | None = None,
-    ):
-        ...
-
-    # Access via agent.snapshots
-    snapshots: Snapshotter
 ```
 
 ### Available Snapshot Fields
@@ -111,7 +85,7 @@ The `include` and `exclude` parameters control which fields are captured:
 - **`include=["field1", "field2"]`** — Explicit list of fields to include
 - **`exclude=["field1"]`** — Fields to exclude (applied after include)
 
-Either `include` or `exclude` must be specified (either as defaults on the Snapshotter or per-call).
+Either `include` or `exclude` must be specified.
 
 ### Behavior
 
@@ -128,19 +102,6 @@ The intent is that anything stored or restored by session-management would be st
 - **`type`, `version`, `timestamp`, and `data`** — Strands-owned. These fields are managed internally and should be treated as opaque. The format of `data` is subject to change; do not modify or depend on its structure.
 - **Serialization** — Strands guarantees that all Strands-owned fields will only contain JSON-serializable values.
 
-### Hooks
-
-A `SnapshotCreatedEvent` hook is fired after `take()` completes, allowing hook providers to add custom data to the snapshot's `app_data` field:
-
-```python
-class CustomDataHook(HookProvider):
-    def register_hooks(self, registry: HookRegistry) -> None:
-        registry.add_callback(SnapshotCreatedEvent, self.on_snapshot_created)
-
-    def on_snapshot_created(self, event: SnapshotCreatedEvent) -> None:
-        event.snapshot["app_data"]["custom_key"] = "custom_value"
-```
-
 ### FileSystemPersister
 
 A `FileSystemPersister` helper class is provided for basic persistence:
@@ -150,11 +111,11 @@ from strands.agent.snapshot import FileSystemPersister
 
 # Save a snapshot
 persister = FileSystemPersister(path="checkpoints/snapshot.json")
-persister.save(agent.snapshots.take())
+persister.save(agent.take_snapshot(include="session"))
 
 # Load a snapshot
 snapshot = persister.load()
-agent.snapshots.load(snapshot)
+agent.load_snapshot(snapshot)
 ```
 
 ### Future Concerns
@@ -162,41 +123,21 @@ agent.snapshots.load(snapshot)
 - Snapshotting for MultiAgent constructs - Snapshot is designed in a way that the snapshot could be reused for multi-agent with a similar api
 - Providing additional storage APIs for snapshot CRUD operations (database, S3, etc.)
 - Providing APIs to customize serialization formats
-- Async support for SnapshotCreatedEvent hook
 
 ## Developer Experience
-
-### Basic Usage with Defaults
-
-```python
-from strands import Agent
-from strands.agent import Snapshotter
-
-# Configure defaults once
-snapshotter = Snapshotter(include="session")
-agent = Agent(tools=[tool1, tool2], snapshots=snapshotter)
-
-# Take snapshots without repeating configuration
-snapshot = agent.snapshots.take()
-snapshot = agent.snapshots.take(app_data={"checkpoint": "before_update"})
-
-# Restore
-agent.snapshots.load(snapshot)
-```
 
 ### Evaluations via Rewind and Replay
 
 ```python
-snapshotter = Snapshotter(include="session")
-agent = Agent(tools=[tool1, tool2], snapshots=snapshotter)
-snapshot = agent.snapshots.take()
+agent = Agent(tools=[tool1, tool2])
+snapshot = agent.take_snapshot(include="session")
 
 result1 = agent("What is the weather?")
 
 # ...
 
-agent2 = Agent(tools=[tool3, tool4], snapshots=snapshotter)
-agent2.snapshots.load(snapshot)
+agent2 = Agent(tools=[tool3, tool4])
+agent2.load_snapshot(snapshot)
 result2 = agent2("What is the weather?")
 # ... 
 # Human/manual evaluation if one outcome was better than the other
@@ -206,54 +147,45 @@ result2 = agent2("What is the weather?")
 ### Advanced Context Management
 
 ```python
-snapshotter = Snapshotter(include="session")
-agent = Agent(
-    conversation_manager=CompactingConversationManager(),
-    snapshots=snapshotter,
-)
-snapshot = agent.snapshots.take(app_data={"checkpoint": "before_long_task"})
+agent = Agent(conversation_manager=CompactingConversationManager())
+snapshot = agent.take_snapshot(include="session", app_data={"checkpoint": "before_long_task"})
 
 # ... later ...
-later_agent = Agent(
-    conversation_manager=CompactingConversationManager(),
-    snapshots=snapshotter,
-)
-later_agent.snapshots.load(snapshot)
+later_agent = Agent(conversation_manager=CompactingConversationManager())
+later_agent.load_snapshot(snapshot)
 ```
 
 ### Persisting Snapshots
 
 ```python
-from strands.agent.snapshot import FileSystemPersister, Snapshotter
+from strands.agent.snapshot import FileSystemPersister
 
-snapshotter = Snapshotter(include="session")
-agent = Agent(tools=[tool1, tool2], snapshots=snapshotter)
+agent = Agent(tools=[tool1, tool2])
 agent("Remember that my favorite color is orange.")
 
 # Save to file
-snapshot = agent.snapshots.take(app_data={"user_id": "123"})
+snapshot = agent.take_snapshot(include="session", app_data={"user_id": "123"})
 FileSystemPersister("snapshot.json").save(snapshot)
 
 # Later, restore from file
 snapshot = FileSystemPersister("snapshot.json").load()
 
-agent = Agent(tools=[tool1, tool2], snapshots=snapshotter)
-agent.snapshots.load(snapshot)
+agent = Agent(tools=[tool1, tool2])
+agent.load_snapshot(snapshot)
 agent("What is my favorite color?")  # "Your favorite color is orange."
 ```
 
-### Overriding Defaults Per-Call
+### Selective Field Inclusion
 
 ```python
-snapshotter = Snapshotter(include="session")
-agent = Agent(snapshots=snapshotter)
+# Include only messages and state
+snapshot = agent.take_snapshot(include=["messages", "state"])
 
-# Use defaults
-snapshot = agent.snapshots.take()
+# Use session preset but exclude interrupt_state
+snapshot = agent.take_snapshot(include="session", exclude=["interrupt_state"])
 
-# Override for this call only
-snapshot = agent.snapshots.take(include=["messages", "state"])
-snapshot = agent.snapshots.take(exclude=["interrupt_state"])
+# Include everything except system_prompt (equivalent to include="session")
+snapshot = agent.take_snapshot(exclude=["system_prompt"])
 ```
 
 ### Edge cases
@@ -261,9 +193,8 @@ snapshot = agent.snapshots.take(exclude=["interrupt_state"])
 Restoring runtime behavior (e.g., tools) is explicitly not supported:
 
 ```python
-snapshotter = Snapshotter(include="session")
-agent1 = Agent(tools=[tool1, tool2], snapshots=snapshotter)
-snapshot = agent1.snapshots.take()
+agent1 = Agent(tools=[tool1, tool2])
+snapshot = agent1.take_snapshot(include="session")
 agent_no = Agent(snapshot)  # tools are NOT restored
 ```
 

--- a/src/strands/agent/__init__.py
+++ b/src/strands/agent/__init__.py
@@ -20,7 +20,7 @@ from .conversation_manager import (
     SlidingWindowConversationManager,
     SummarizingConversationManager,
 )
-from .snapshot import FileSystemPersister, Snapshot, Snapshotter
+from .snapshot import FileSystemPersister, Snapshot, Snapshottable
 
 __all__ = [
     "Agent",
@@ -31,7 +31,7 @@ __all__ = [
     "NullConversationManager",
     "SlidingWindowConversationManager",
     "Snapshot",
-    "Snapshotter",
+    "Snapshottable",
     "SummarizingConversationManager",
     "ModelRetryStrategy",
 ]

--- a/src/strands/agent/__init__.py
+++ b/src/strands/agent/__init__.py
@@ -20,7 +20,7 @@ from .conversation_manager import (
     SlidingWindowConversationManager,
     SummarizingConversationManager,
 )
-from .snapshot import FileSystemPersister, Snapshot, Snapshottable
+from .snapshot import FileSystemPersister, Snapshot, Snapshotter
 
 __all__ = [
     "Agent",
@@ -31,7 +31,7 @@ __all__ = [
     "NullConversationManager",
     "SlidingWindowConversationManager",
     "Snapshot",
-    "Snapshottable",
+    "Snapshotter",
     "SummarizingConversationManager",
     "ModelRetryStrategy",
 ]

--- a/src/strands/agent/__init__.py
+++ b/src/strands/agent/__init__.py
@@ -5,6 +5,7 @@ It includes:
 - Agent: The main interface for interacting with AI models and tools
 - ConversationManager: Classes for managing conversation history and context windows
 - Retry Strategies: Configurable retry behavior for model calls
+- Snapshot: Point-in-time capture and restore of agent state
 """
 
 from typing import Any
@@ -19,14 +20,18 @@ from .conversation_manager import (
     SlidingWindowConversationManager,
     SummarizingConversationManager,
 )
+from .snapshot import FileSystemPersister, Snapshot, Snapshottable
 
 __all__ = [
     "Agent",
     "AgentBase",
     "AgentResult",
     "ConversationManager",
+    "FileSystemPersister",
     "NullConversationManager",
     "SlidingWindowConversationManager",
+    "Snapshot",
+    "Snapshottable",
     "SummarizingConversationManager",
     "ModelRetryStrategy",
 ]

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -32,7 +32,7 @@ from ..tools._tool_helpers import generate_missing_tool_result_content
 
 if TYPE_CHECKING:
     from ..tools import ToolProvider
-    from .snapshot import Snapshot, SnapshotPreset
+    from .snapshot import Snapshot, SnapshotPreset, Snapshotter
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from ..hooks import (
     AfterInvocationEvent,
@@ -130,6 +130,7 @@ class Agent(AgentBase):
         structured_output_prompt: str | None = None,
         tool_executor: ToolExecutor | None = None,
         retry_strategy: ModelRetryStrategy | _DefaultRetryStrategySentinel | None = _DEFAULT_RETRY_STRATEGY,
+        snapshots: "Snapshotter | None" = None,
     ):
         """Initialize the Agent with the specified configuration.
 
@@ -187,6 +188,9 @@ class Agent(AgentBase):
             retry_strategy: Strategy for retrying model calls on throttling or other transient errors.
                 Defaults to ModelRetryStrategy with max_attempts=6, initial_delay=4s, max_delay=240s.
                 Implement a custom HookProvider for custom retry logic, or pass None to disable retries.
+            snapshots: Snapshotter instance for managing agent snapshots.
+                If provided, enables snapshot operations via agent.snapshots.
+                If None, a default Snapshotter is created.
 
         Raises:
             ValueError: If agent id contains path separators.
@@ -304,6 +308,12 @@ class Agent(AgentBase):
             for hook in hooks:
                 self.hooks.add_hook(hook)
         self.hooks.invoke_callbacks(AgentInitializedEvent(agent=self))
+
+        # Initialize snapshotter
+        from .snapshot import Snapshotter as SnapshotterClass
+
+        self.snapshots = snapshots if snapshots is not None else SnapshotterClass()
+        self.snapshots._bind(self)
 
     @property
     def system_prompt(self) -> str | None:
@@ -932,154 +942,3 @@ class Agent(AgentBase):
             redacted_content = [{"text": redact_message}]
 
         return redacted_content
-
-    def take_snapshot(
-        self,
-        app_data: dict[str, Any] | None = None,
-        include: "SnapshotPreset | list[str] | None" = None,
-        exclude: list[str] | None = None,
-    ) -> "Snapshot":
-        """Capture current agent state as a snapshot.
-
-        Creates a point-in-time capture of the agent's evolving state. The fields
-        included in the snapshot are controlled by the `include` and `exclude` parameters.
-
-        Available fields:
-        - messages: Conversation history
-        - state: Custom application state (agent.state)
-        - conversation_manager_state: Internal state of the conversation manager
-        - interrupt_state: State of any active interrupts
-        - system_prompt: The agent's system prompt
-
-        Args:
-            app_data: Optional application-owned data to include in the snapshot.
-                Strands does not read or modify this data. Use it to store
-                application-specific context like user IDs, session names, etc.
-            include: Fields to include in the snapshot. Can be:
-                - "session": Preset that includes messages, state, conversation_manager_state,
-                  and interrupt_state (excludes system_prompt)
-                - A list of field names to include
-                Required if exclude is not set.
-            exclude: Fields to exclude from the snapshot. Applied after include.
-                For example: `take_snapshot(include="session", exclude=["messages"])`
-
-        Returns:
-            A Snapshot containing the captured state.
-
-        Raises:
-            ValueError: If neither include nor exclude is specified.
-
-        Example:
-            ```python
-            # Take a snapshot with session preset
-            snapshot = agent.take_snapshot(include="session", app_data={"checkpoint": "before_update"})
-
-            # Take a snapshot with custom fields
-            snapshot = agent.take_snapshot(include=["messages", "state"])
-
-            # Exclude specific fields from session preset
-            snapshot = agent.take_snapshot(include="session", exclude=["interrupt_state"])
-
-            # Later, restore if needed
-            agent.load_snapshot(snapshot)
-            ```
-        """
-        from ..hooks import SnapshotCreatedEvent
-        from .snapshot import SNAPSHOT_VERSION, Snapshot, create_timestamp, resolve_snapshot_fields
-
-        logger.debug("agent_id=<%s> | taking snapshot", self.agent_id)
-
-        # Resolve which fields to include
-        fields = resolve_snapshot_fields(include, exclude)
-
-        # Build the data dict with only the requested fields
-        data: dict[str, Any] = {}
-
-        if "messages" in fields:
-            data["messages"] = list(self.messages)
-
-        if "state" in fields:
-            data["state"] = self.state.get()
-
-        if "conversation_manager_state" in fields:
-            data["conversation_manager_state"] = self.conversation_manager.get_state()
-
-        if "interrupt_state" in fields:
-            data["interrupt_state"] = self._interrupt_state.to_dict()
-
-        if "system_prompt" in fields:
-            data["system_prompt"] = self._system_prompt
-
-        snapshot: Snapshot = {
-            "type": "agent",
-            "version": SNAPSHOT_VERSION,
-            "timestamp": create_timestamp(),
-            "data": data,
-            "app_data": app_data or {},
-        }
-
-        # TODO: This hook invocation is synchronous. Consider adding async support
-        # for hooks that need to perform async operations when a snapshot is created.
-        # Fire hook to allow custom data to be added to the snapshot
-        self.hooks.invoke_callbacks(SnapshotCreatedEvent(agent=self, snapshot=snapshot))
-
-        logger.debug("agent_id=<%s>, message_count=<%d> | snapshot taken", self.agent_id, len(self.messages))
-        return snapshot
-
-    def load_snapshot(self, snapshot: "Snapshot") -> None:
-        """Restore agent state from a snapshot.
-
-        Restores the agent's evolving state from a previously captured snapshot.
-        Only fields that were included when the snapshot was taken will be restored.
-
-        Restorable fields:
-        - messages: Replaces current conversation history
-        - state: Replaces current application state
-        - conversation_manager_state: Restores conversation manager state
-        - interrupt_state: Restores interrupt state
-        - system_prompt: Restores the system prompt
-
-        Note: Agent definition aspects not included in the snapshot (tools, model,
-        conversation_manager instance) are not affected.
-
-        Args:
-            snapshot: The snapshot to restore from.
-
-        Raises:
-            ValueError: If the snapshot type is not "agent".
-
-        Example:
-            ```python
-            # Load a previously saved snapshot
-            snapshot = FileSystemPersister("checkpoint.json").load()
-            agent.load_snapshot(snapshot)
-            ```
-        """
-        logger.debug("agent_id=<%s> | loading snapshot", self.agent_id)
-
-        if snapshot["type"] != "agent":
-            raise ValueError(f"snapshot type=<{snapshot['type']}> | expected snapshot type 'agent'")
-
-        data = snapshot["data"]
-
-        # Restore messages
-        if "messages" in data:
-            self.messages = list(data["messages"])
-
-        # Restore agent state
-        if "state" in data:
-            self.state = AgentState(data["state"])
-
-        # Restore conversation manager state
-        if "conversation_manager_state" in data:
-            self.conversation_manager.restore_from_session(data["conversation_manager_state"])
-
-        # Restore interrupt state
-        if "interrupt_state" in data:
-            self._interrupt_state = _InterruptState.from_dict(data["interrupt_state"])
-
-        # Restore system prompt
-        if "system_prompt" in data:
-            self.system_prompt = data["system_prompt"]
-
-        logger.debug("agent_id=<%s>, message_count=<%d> | snapshot loaded", self.agent_id, len(self.messages))

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -32,7 +32,7 @@ from ..tools._tool_helpers import generate_missing_tool_result_content
 
 if TYPE_CHECKING:
     from ..tools import ToolProvider
-    from .snapshot import Snapshot, SnapshotPreset, Snapshotter
+    from .snapshot import Snapshot, SnapshotPreset
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from ..hooks import (
     AfterInvocationEvent,
@@ -130,7 +130,6 @@ class Agent(AgentBase):
         structured_output_prompt: str | None = None,
         tool_executor: ToolExecutor | None = None,
         retry_strategy: ModelRetryStrategy | _DefaultRetryStrategySentinel | None = _DEFAULT_RETRY_STRATEGY,
-        snapshots: "Snapshotter | None" = None,
     ):
         """Initialize the Agent with the specified configuration.
 
@@ -188,9 +187,6 @@ class Agent(AgentBase):
             retry_strategy: Strategy for retrying model calls on throttling or other transient errors.
                 Defaults to ModelRetryStrategy with max_attempts=6, initial_delay=4s, max_delay=240s.
                 Implement a custom HookProvider for custom retry logic, or pass None to disable retries.
-            snapshots: Snapshotter instance for managing agent snapshots.
-                If provided, enables snapshot operations via agent.snapshots.
-                If None, a default Snapshotter is created.
 
         Raises:
             ValueError: If agent id contains path separators.
@@ -308,12 +304,6 @@ class Agent(AgentBase):
             for hook in hooks:
                 self.hooks.add_hook(hook)
         self.hooks.invoke_callbacks(AgentInitializedEvent(agent=self))
-
-        # Initialize snapshotter
-        from .snapshot import Snapshotter as SnapshotterClass
-
-        self.snapshots = snapshots if snapshots is not None else SnapshotterClass()
-        self.snapshots._bind(self)
 
     @property
     def system_prompt(self) -> str | None:
@@ -942,3 +932,148 @@ class Agent(AgentBase):
             redacted_content = [{"text": redact_message}]
 
         return redacted_content
+
+    def take_snapshot(
+        self,
+        app_data: dict[str, Any] | None = None,
+        include: "SnapshotPreset | list[str] | None" = None,
+        exclude: list[str] | None = None,
+    ) -> "Snapshot":
+        """Capture current agent state as a snapshot.
+
+        Creates a point-in-time capture of the agent's evolving state. The fields
+        included in the snapshot are controlled by the `include` and `exclude` parameters.
+
+        Available fields:
+        - messages: Conversation history
+        - state: Custom application state (agent.state)
+        - conversation_manager_state: Internal state of the conversation manager
+        - interrupt_state: State of any active interrupts
+        - system_prompt: The agent's system prompt
+
+        Args:
+            app_data: Optional application-owned data to include in the snapshot.
+                Strands does not read or modify this data. Use it to store
+                application-specific context like user IDs, session names, etc.
+            include: Fields to include in the snapshot. Can be:
+                - "session": Preset that includes messages, state, conversation_manager_state,
+                  and interrupt_state (excludes system_prompt)
+                - A list of field names to include
+                Required if exclude is not set.
+            exclude: Fields to exclude from the snapshot. Applied after include.
+                For example: `take_snapshot(include="session", exclude=["messages"])`
+
+        Returns:
+            A Snapshot containing the captured state.
+
+        Raises:
+            ValueError: If neither include nor exclude is specified.
+
+        Example:
+            ```python
+            # Take a snapshot with session preset
+            snapshot = agent.take_snapshot(include="session", app_data={"checkpoint": "before_update"})
+
+            # Take a snapshot with custom fields
+            snapshot = agent.take_snapshot(include=["messages", "state"])
+
+            # Exclude specific fields from session preset
+            snapshot = agent.take_snapshot(include="session", exclude=["interrupt_state"])
+
+            # Later, restore if needed
+            agent.load_snapshot(snapshot)
+            ```
+        """
+        from .snapshot import SNAPSHOT_VERSION, Snapshot, create_timestamp, resolve_snapshot_fields
+
+        logger.debug("agent_id=<%s> | taking snapshot", self.agent_id)
+
+        # Resolve which fields to include
+        fields = resolve_snapshot_fields(include, exclude)
+
+        # Build the data dict with only the requested fields
+        data: dict[str, Any] = {}
+
+        if "messages" in fields:
+            data["messages"] = list(self.messages)
+
+        if "state" in fields:
+            data["state"] = self.state.get()
+
+        if "conversation_manager_state" in fields:
+            data["conversation_manager_state"] = self.conversation_manager.get_state()
+
+        if "interrupt_state" in fields:
+            data["interrupt_state"] = self._interrupt_state.to_dict()
+
+        if "system_prompt" in fields:
+            data["system_prompt"] = self._system_prompt
+
+        snapshot: Snapshot = {
+            "type": "agent",
+            "version": SNAPSHOT_VERSION,
+            "timestamp": create_timestamp(),
+            "data": data,
+            "app_data": app_data or {},
+        }
+
+        logger.debug("agent_id=<%s>, message_count=<%d> | snapshot taken", self.agent_id, len(self.messages))
+        return snapshot
+
+    def load_snapshot(self, snapshot: "Snapshot") -> None:
+        """Restore agent state from a snapshot.
+
+        Restores the agent's evolving state from a previously captured snapshot.
+        Only fields that were included when the snapshot was taken will be restored.
+
+        Restorable fields:
+        - messages: Replaces current conversation history
+        - state: Replaces current application state
+        - conversation_manager_state: Restores conversation manager state
+        - interrupt_state: Restores interrupt state
+        - system_prompt: Restores the system prompt
+
+        Note: Agent definition aspects not included in the snapshot (tools, model,
+        conversation_manager instance) are not affected.
+
+        Args:
+            snapshot: The snapshot to restore from.
+
+        Raises:
+            ValueError: If the snapshot type is not "agent".
+
+        Example:
+            ```python
+            # Load a previously saved snapshot
+            snapshot = FileSystemPersister("checkpoint.json").load()
+            agent.load_snapshot(snapshot)
+            ```
+        """
+        logger.debug("agent_id=<%s> | loading snapshot", self.agent_id)
+
+        if snapshot["type"] != "agent":
+            raise ValueError(f"snapshot type=<{snapshot['type']}> | expected snapshot type 'agent'")
+
+        data = snapshot["data"]
+
+        # Restore messages
+        if "messages" in data:
+            self.messages = list(data["messages"])
+
+        # Restore agent state
+        if "state" in data:
+            self.state = AgentState(data["state"])
+
+        # Restore conversation manager state
+        if "conversation_manager_state" in data:
+            self.conversation_manager.restore_from_session(data["conversation_manager_state"])
+
+        # Restore interrupt state
+        if "interrupt_state" in data:
+            self._interrupt_state = _InterruptState.from_dict(data["interrupt_state"])
+
+        # Restore system prompt
+        if "system_prompt" in data:
+            self.system_prompt = data["system_prompt"]
+
+        logger.debug("agent_id=<%s>, message_count=<%d> | snapshot loaded", self.agent_id, len(self.messages))

--- a/src/strands/agent/snapshot.py
+++ b/src/strands/agent/snapshot.py
@@ -11,16 +11,11 @@ SessionManager works incrementally, recording messages as they happen, while sna
 capture the complete state at a specific point in time.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
-
-if TYPE_CHECKING:
-    from .agent import Agent
+from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +51,9 @@ class Snapshot(TypedDict):
 
     Example:
         ```python
-        snapshot = agent.snapshots.take(app_data={"user_id": "123"})
+        snapshot = agent.take_snapshot(app_data={"user_id": "123"})
         # Later...
-        agent.snapshots.load(snapshot)
+        agent.load_snapshot(snapshot)
         ```
     """
 
@@ -69,258 +64,51 @@ class Snapshot(TypedDict):
     app_data: dict[str, Any]
 
 
-class Snapshotter:
-    """Manages snapshot operations for an agent.
+@runtime_checkable
+class Snapshottable(Protocol):
+    """Protocol for objects that support snapshot operations.
 
-    The Snapshotter provides methods to capture and restore agent state at specific
-    points in time. It can be configured with default include/exclude settings that
-    apply to all snapshot operations, while still allowing per-call overrides.
+    This protocol defines the contract for taking and loading snapshots,
+    enabling future extensibility to other types (multi-agent, etc.).
 
     Example:
         ```python
-        # Create agent with default snapshot settings
-        snapshotter = Snapshotter(include="session")
-        agent = Agent(snapshots=snapshotter)
-
-        # Take snapshot using defaults
-        snapshot = agent.snapshots.take()
-
-        # Override defaults for specific snapshot
-        snapshot = agent.snapshots.take(include=["messages", "state"])
-
-        # Restore from snapshot
-        agent.snapshots.load(snapshot)
+        def checkpoint(obj: Snapshottable, path: str) -> None:
+            snapshot = obj.take_snapshot(include="session")
+            FileSystemPersister(path).save(snapshot)
         ```
-
-    Attributes:
-        include: Default fields to include in snapshots.
-        exclude: Default fields to exclude from snapshots.
     """
 
-    def __init__(
-        self,
-        include: SnapshotPreset | list[str] | None = None,
-        exclude: list[str] | None = None,
-    ) -> None:
-        """Initialize the Snapshotter with default settings.
-
-        Args:
-            include: Default fields to include in snapshots. Can be:
-                - "session": Preset that includes messages, state, conversation_manager_state,
-                  and interrupt_state (excludes system_prompt)
-                - A list of field names to include
-            exclude: Default fields to exclude from snapshots. Applied after include.
-
-        Example:
-            ```python
-            # Use session preset by default
-            snapshotter = Snapshotter(include="session")
-
-            # Exclude interrupt_state by default
-            snapshotter = Snapshotter(include="session", exclude=["interrupt_state"])
-            ```
-        """
-        self._default_include = include
-        self._default_exclude = exclude
-        self._agent: Agent | None = None
-
-    def _bind(self, agent: Agent) -> None:
-        """Bind this snapshotter to an agent.
-
-        Args:
-            agent: The agent to bind to.
-        """
-        self._agent = agent
-
-    def take(
+    def take_snapshot(
         self,
         app_data: dict[str, Any] | None = None,
         include: SnapshotPreset | list[str] | None = None,
         exclude: list[str] | None = None,
     ) -> Snapshot:
-        """Capture current agent state as a snapshot.
-
-        Creates a point-in-time capture of the agent's evolving state. The fields
-        included in the snapshot are controlled by the `include` and `exclude` parameters,
-        falling back to the defaults configured on the Snapshotter.
-
-        Available fields:
-        - messages: Conversation history
-        - state: Custom application state (agent.state)
-        - conversation_manager_state: Internal state of the conversation manager
-        - interrupt_state: State of any active interrupts
-        - system_prompt: The agent's system prompt
+        """Capture current state as a snapshot.
 
         Args:
             app_data: Optional application-owned data to include in the snapshot.
-                Strands does not read or modify this data. Use it to store
-                application-specific context like user IDs, session names, etc.
-            include: Fields to include in the snapshot. Overrides the default.
-                Can be "session" preset or a list of field names.
-            exclude: Fields to exclude from the snapshot. Overrides the default.
+                Strands does not read or modify this data.
+            include: Fields to include in the snapshot. Can be a named preset
+                (e.g., "session") or a list of field names. Required if exclude is not set.
+            exclude: Fields to exclude from the snapshot. Applied after include.
 
         Returns:
             A Snapshot containing the captured state.
-
-        Raises:
-            RuntimeError: If the snapshotter is not bound to an agent.
-            ValueError: If neither include nor exclude is specified (and no defaults set).
-
-        Example:
-            ```python
-            # Take a snapshot with defaults
-            snapshot = agent.snapshots.take()
-
-            # Take a snapshot with app_data
-            snapshot = agent.snapshots.take(app_data={"checkpoint": "before_update"})
-
-            # Override defaults for this snapshot
-            snapshot = agent.snapshots.take(include=["messages", "state"])
-            ```
         """
-        if self._agent is None:
-            raise RuntimeError("Snapshotter is not bound to an agent")
+        ...
 
-        from ..hooks import SnapshotCreatedEvent
-
-        # Use provided values or fall back to defaults
-        effective_include = include if include is not None else self._default_include
-        effective_exclude = exclude if exclude is not None else self._default_exclude
-
-        logger.debug("agent_id=<%s> | taking snapshot", self._agent.agent_id)
-
-        # Resolve which fields to include
-        fields = resolve_snapshot_fields(effective_include, effective_exclude)
-
-        # Build the data dict with only the requested fields
-        data: dict[str, Any] = {}
-
-        if "messages" in fields:
-            data["messages"] = list(self._agent.messages)
-
-        if "state" in fields:
-            data["state"] = self._agent.state.get()
-
-        if "conversation_manager_state" in fields:
-            data["conversation_manager_state"] = self._agent.conversation_manager.get_state()
-
-        if "interrupt_state" in fields:
-            data["interrupt_state"] = self._agent._interrupt_state.to_dict()
-
-        if "system_prompt" in fields:
-            data["system_prompt"] = self._agent._system_prompt
-
-        snapshot: Snapshot = {
-            "type": "agent",
-            "version": SNAPSHOT_VERSION,
-            "timestamp": create_timestamp(),
-            "data": data,
-            "app_data": app_data or {},
-        }
-
-        # TODO: This hook invocation is synchronous. Consider adding async support
-        # for hooks that need to perform async operations when a snapshot is created.
-        # Fire hook to allow custom data to be added to the snapshot
-        self._agent.hooks.invoke_callbacks(SnapshotCreatedEvent(agent=self._agent, snapshot=snapshot))
-
-        logger.debug(
-            "agent_id=<%s>, message_count=<%d> | snapshot taken", self._agent.agent_id, len(self._agent.messages)
-        )
-        return snapshot
-
-    async def take_async(
-        self,
-        app_data: dict[str, Any] | None = None,
-        include: SnapshotPreset | list[str] | None = None,
-        exclude: list[str] | None = None,
-    ) -> Snapshot:
-        """Capture current agent state as a snapshot asynchronously.
-
-        This is the async version of take(). Currently, the implementation is
-        synchronous, but this method is provided for API consistency and future
-        async hook support.
-
-        Args:
-            app_data: Optional application-owned data to include in the snapshot.
-            include: Fields to include in the snapshot. Overrides the default.
-            exclude: Fields to exclude from the snapshot. Overrides the default.
-
-        Returns:
-            A Snapshot containing the captured state.
-
-        Raises:
-            RuntimeError: If the snapshotter is not bound to an agent.
-            ValueError: If neither include nor exclude is specified (and no defaults set).
-        """
-        # Currently synchronous, but provides async API for future hook support
-        return self.take(app_data=app_data, include=include, exclude=exclude)
-
-    def load(self, snapshot: Snapshot) -> None:
-        """Restore agent state from a snapshot.
-
-        Restores the agent's evolving state from a previously captured snapshot.
-        Only fields that were included when the snapshot was taken will be restored.
-
-        Restorable fields:
-        - messages: Replaces current conversation history
-        - state: Replaces current application state
-        - conversation_manager_state: Restores conversation manager state
-        - interrupt_state: Restores interrupt state
-        - system_prompt: Restores the system prompt
-
-        Note: Agent definition aspects not included in the snapshot (tools, model,
-        conversation_manager instance) are not affected.
+    def load_snapshot(self, snapshot: Snapshot) -> None:
+        """Restore state from a snapshot.
 
         Args:
             snapshot: The snapshot to restore from.
 
         Raises:
-            RuntimeError: If the snapshotter is not bound to an agent.
-            ValueError: If the snapshot type is not "agent".
-
-        Example:
-            ```python
-            # Load a previously saved snapshot
-            snapshot = FileSystemPersister("checkpoint.json").load()
-            agent.snapshots.load(snapshot)
-            ```
+            ValueError: If the snapshot type doesn't match or is invalid.
         """
-        if self._agent is None:
-            raise RuntimeError("Snapshotter is not bound to an agent")
-
-        from ..interrupt import _InterruptState
-        from .state import AgentState
-
-        logger.debug("agent_id=<%s> | loading snapshot", self._agent.agent_id)
-
-        if snapshot["type"] != "agent":
-            raise ValueError(f"snapshot type=<{snapshot['type']}> | expected snapshot type 'agent'")
-
-        data = snapshot["data"]
-
-        # Restore messages
-        if "messages" in data:
-            self._agent.messages = list(data["messages"])
-
-        # Restore agent state
-        if "state" in data:
-            self._agent.state = AgentState(data["state"])
-
-        # Restore conversation manager state
-        if "conversation_manager_state" in data:
-            self._agent.conversation_manager.restore_from_session(data["conversation_manager_state"])
-
-        # Restore interrupt state
-        if "interrupt_state" in data:
-            self._agent._interrupt_state = _InterruptState.from_dict(data["interrupt_state"])
-
-        # Restore system prompt
-        if "system_prompt" in data:
-            self._agent.system_prompt = data["system_prompt"]
-
-        logger.debug(
-            "agent_id=<%s>, message_count=<%d> | snapshot loaded", self._agent.agent_id, len(self._agent.messages)
-        )
+        ...
 
 
 class FileSystemPersister:
@@ -334,11 +122,11 @@ class FileSystemPersister:
         ```python
         # Save a snapshot
         persister = FileSystemPersister(path="checkpoints/snapshot.json")
-        persister.save(agent.snapshots.take())
+        persister.save(agent.take_snapshot(include="session"))
 
         # Load a snapshot
         snapshot = persister.load()
-        agent.snapshots.load(snapshot)
+        agent.load_snapshot(snapshot)
         ```
 
     Attributes:
@@ -363,7 +151,7 @@ class FileSystemPersister:
 
         Example:
             ```python
-            snapshot = agent.snapshots.take()
+            snapshot = agent.take_snapshot(include="session")
             FileSystemPersister("state.json").save(snapshot)
             ```
         """
@@ -385,7 +173,7 @@ class FileSystemPersister:
         Example:
             ```python
             snapshot = FileSystemPersister("state.json").load()
-            agent.snapshots.load(snapshot)
+            agent.load_snapshot(snapshot)
             ```
         """
         logger.debug("path=<%s> | loading snapshot from filesystem", self.path)

--- a/src/strands/agent/snapshot.py
+++ b/src/strands/agent/snapshot.py
@@ -1,0 +1,172 @@
+"""Low-level snapshot API for capturing and restoring agent state.
+
+This module provides the snapshot infrastructure for point-in-time capture and restore
+of agent state. Snapshots enable:
+- Point-in-time capture: Save complete agent state at any moment
+- Arbitrary restore: Restore to any previously captured state
+- Context management: Enable advanced strategies with state modifications
+
+The snapshot API is independent of SessionManager and provides a different capability:
+SessionManager works incrementally, recording messages as they happen, while snapshots
+capture the complete state at a specific point in time.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol, TypedDict, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# Current snapshot version for forward compatibility
+SNAPSHOT_VERSION = "1.0"
+
+
+class Snapshot(TypedDict):
+    """Point-in-time capture of agent state.
+
+    A Snapshot captures the complete evolving state of an agent at a specific moment.
+    It is designed for easy JSON serialization and supports both Strands-managed state
+    and application-owned metadata.
+
+    Attributes:
+        type: String identifying the snapshot type (e.g., "agent"). Strands-owned.
+        version: Version string for forward compatibility. Strands-owned.
+        timestamp: ISO 8601 timestamp of when the snapshot was taken. Strands-owned.
+        state: Dict containing the agent's evolving state. Strands-owned, opaque to callers.
+        metadata: Dict for application-owned data. Strands does not read or modify this.
+
+    Example:
+        ```python
+        snapshot = agent.take_snapshot(metadata={"user_id": "123"})
+        # Later...
+        agent.load_snapshot(snapshot)
+        ```
+    """
+
+    type: str
+    version: str
+    timestamp: str
+    state: dict[str, Any]
+    metadata: dict[str, Any]
+
+
+@runtime_checkable
+class Snapshottable(Protocol):
+    """Protocol for objects that support snapshot operations.
+
+    This protocol defines the contract for taking and loading snapshots,
+    enabling future extensibility to other types (multi-agent, etc.).
+
+    Example:
+        ```python
+        def checkpoint(obj: Snapshottable, path: str) -> None:
+            snapshot = obj.take_snapshot()
+            FileSystemPersister(path).save(snapshot)
+        ```
+    """
+
+    def take_snapshot(self, metadata: dict[str, Any] | None = None) -> Snapshot:
+        """Capture current state as a snapshot.
+
+        Args:
+            metadata: Optional application-owned data to include in the snapshot.
+                Strands does not read or modify this data.
+
+        Returns:
+            A Snapshot containing the complete current state.
+        """
+        ...
+
+    def load_snapshot(self, snapshot: Snapshot) -> None:
+        """Restore state from a snapshot.
+
+        Args:
+            snapshot: The snapshot to restore from.
+
+        Raises:
+            ValueError: If the snapshot type doesn't match or is invalid.
+        """
+        ...
+
+
+class FileSystemPersister:
+    """Persistence helper for saving and loading snapshots from the filesystem.
+
+    This class provides a simple pattern for persisting snapshots to JSON files.
+    It handles JSON serialization/deserialization and creates parent directories
+    as needed.
+
+    Example:
+        ```python
+        # Save a snapshot
+        persister = FileSystemPersister(path="checkpoints/snapshot.json")
+        persister.save(agent.take_snapshot())
+
+        # Load a snapshot
+        snapshot = persister.load()
+        agent.load_snapshot(snapshot)
+        ```
+
+    Attributes:
+        path: Path to the snapshot file.
+    """
+
+    def __init__(self, path: str) -> None:
+        """Initialize the persister with a file path.
+
+        Args:
+            path: Path where the snapshot will be saved/loaded.
+        """
+        self.path = Path(path)
+
+    def save(self, snapshot: Snapshot) -> None:
+        """Save a snapshot to the filesystem.
+
+        Creates parent directories if they don't exist.
+
+        Args:
+            snapshot: The snapshot to save.
+
+        Example:
+            ```python
+            snapshot = agent.take_snapshot()
+            FileSystemPersister("state.json").save(snapshot)
+            ```
+        """
+        logger.debug("path=<%s> | saving snapshot to filesystem", self.path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(snapshot, f, indent=2)
+        logger.debug("path=<%s> | snapshot saved successfully", self.path)
+
+    def load(self) -> Snapshot:
+        """Load a snapshot from the filesystem.
+
+        Returns:
+            The loaded snapshot.
+
+        Raises:
+            FileNotFoundError: If the snapshot file doesn't exist.
+
+        Example:
+            ```python
+            snapshot = FileSystemPersister("state.json").load()
+            agent.load_snapshot(snapshot)
+            ```
+        """
+        logger.debug("path=<%s> | loading snapshot from filesystem", self.path)
+        with open(self.path, encoding="utf-8") as f:
+            snapshot: Snapshot = json.load(f)
+        logger.debug("path=<%s> | snapshot loaded successfully", self.path)
+        return snapshot
+
+
+def create_timestamp() -> str:
+    """Create an ISO 8601 timestamp for the current time.
+
+    Returns:
+        ISO 8601 formatted timestamp string.
+    """
+    return datetime.now(timezone.utc).isoformat()

--- a/src/strands/hooks/__init__.py
+++ b/src/strands/hooks/__init__.py
@@ -44,8 +44,6 @@ from .events import (
     BeforeToolCallEvent,
     MessageAddedEvent,
     MultiAgentInitializedEvent,
-    # Snapshot hook events
-    SnapshotCreatedEvent,
 )
 from .registry import BaseHookEvent, HookCallback, HookEvent, HookProvider, HookRegistry
 
@@ -69,5 +67,4 @@ __all__ = [
     "BeforeMultiAgentInvocationEvent",
     "BeforeNodeCallEvent",
     "MultiAgentInitializedEvent",
-    "SnapshotCreatedEvent",
 ]

--- a/src/strands/hooks/__init__.py
+++ b/src/strands/hooks/__init__.py
@@ -44,6 +44,8 @@ from .events import (
     BeforeToolCallEvent,
     MessageAddedEvent,
     MultiAgentInitializedEvent,
+    # Snapshot hook events
+    SnapshotCreatedEvent,
 )
 from .registry import BaseHookEvent, HookCallback, HookEvent, HookProvider, HookRegistry
 
@@ -67,4 +69,5 @@ __all__ = [
     "BeforeMultiAgentInvocationEvent",
     "BeforeNodeCallEvent",
     "MultiAgentInitializedEvent",
+    "SnapshotCreatedEvent",
 ]

--- a/src/strands/hooks/events.py
+++ b/src/strands/hooks/events.py
@@ -388,32 +388,3 @@ class AfterMultiAgentInvocationEvent(BaseHookEvent):
         """True to invoke callbacks in reverse order."""
         return True
 
-
-# Snapshot hook events
-@dataclass
-class SnapshotCreatedEvent(HookEvent):
-    """Event triggered after a snapshot has been created.
-
-    This event is fired after the agent has created a snapshot, allowing hook
-    providers to add their own custom data to the snapshot's app_data field
-    before it is returned to the caller.
-
-    Attributes:
-        snapshot: The snapshot that was created. Hook providers can modify
-            the app_data field to add application-specific data.
-
-    Example:
-        ```python
-        class CustomDataHook(HookProvider):
-            def register_hooks(self, registry: HookRegistry) -> None:
-                registry.add_callback(SnapshotCreatedEvent, self.on_snapshot_created)
-
-            def on_snapshot_created(self, event: SnapshotCreatedEvent) -> None:
-                event.snapshot["app_data"]["custom_key"] = "custom_value"
-        ```
-    """
-
-    snapshot: dict[str, Any]  # Snapshot TypedDict
-
-    def _can_write(self, name: str) -> bool:
-        return name == "snapshot"

--- a/src/strands/hooks/events.py
+++ b/src/strands/hooks/events.py
@@ -395,12 +395,12 @@ class SnapshotCreatedEvent(HookEvent):
     """Event triggered after a snapshot has been created.
 
     This event is fired after the agent has created a snapshot, allowing hook
-    providers to add their own custom data to the snapshot's metadata field
+    providers to add their own custom data to the snapshot's app_data field
     before it is returned to the caller.
 
     Attributes:
         snapshot: The snapshot that was created. Hook providers can modify
-            the metadata field to add application-specific data.
+            the app_data field to add application-specific data.
 
     Example:
         ```python
@@ -409,7 +409,7 @@ class SnapshotCreatedEvent(HookEvent):
                 registry.add_callback(SnapshotCreatedEvent, self.on_snapshot_created)
 
             def on_snapshot_created(self, event: SnapshotCreatedEvent) -> None:
-                event.snapshot["metadata"]["custom_key"] = "custom_value"
+                event.snapshot["app_data"]["custom_key"] = "custom_value"
         ```
     """
 

--- a/src/strands/hooks/events.py
+++ b/src/strands/hooks/events.py
@@ -387,3 +387,33 @@ class AfterMultiAgentInvocationEvent(BaseHookEvent):
     def should_reverse_callbacks(self) -> bool:
         """True to invoke callbacks in reverse order."""
         return True
+
+
+# Snapshot hook events
+@dataclass
+class SnapshotCreatedEvent(HookEvent):
+    """Event triggered after a snapshot has been created.
+
+    This event is fired after the agent has created a snapshot, allowing hook
+    providers to add their own custom data to the snapshot's metadata field
+    before it is returned to the caller.
+
+    Attributes:
+        snapshot: The snapshot that was created. Hook providers can modify
+            the metadata field to add application-specific data.
+
+    Example:
+        ```python
+        class CustomDataHook(HookProvider):
+            def register_hooks(self, registry: HookRegistry) -> None:
+                registry.add_callback(SnapshotCreatedEvent, self.on_snapshot_created)
+
+            def on_snapshot_created(self, event: SnapshotCreatedEvent) -> None:
+                event.snapshot["metadata"]["custom_key"] = "custom_value"
+        ```
+    """
+
+    snapshot: dict[str, Any]  # Snapshot TypedDict
+
+    def _can_write(self, name: str) -> bool:
+        return name == "snapshot"

--- a/tests/strands/agent/test_snapshot.py
+++ b/tests/strands/agent/test_snapshot.py
@@ -25,15 +25,15 @@ class TestSnapshotTypedDict:
             "type": "agent",
             "version": "1.0",
             "timestamp": "2024-01-01T00:00:00+00:00",
-            "state": {},
-            "metadata": {},
+            "data": {},
+            "app_data": {},
         }
 
         assert snapshot["type"] == "agent"
         assert snapshot["version"] == "1.0"
         assert snapshot["timestamp"] == "2024-01-01T00:00:00+00:00"
-        assert snapshot["state"] == {}
-        assert snapshot["metadata"] == {}
+        assert snapshot["data"] == {}
+        assert snapshot["app_data"] == {}
 
     def test_snapshot_is_json_serializable(self):
         """Verify Snapshot can be serialized to JSON."""
@@ -41,8 +41,8 @@ class TestSnapshotTypedDict:
             "type": "agent",
             "version": "1.0",
             "timestamp": "2024-01-01T00:00:00+00:00",
-            "state": {"messages": [], "state": {"key": "value"}},
-            "metadata": {"user_id": "123", "session_name": "test"},
+            "data": {"messages": [], "state": {"key": "value"}},
+            "app_data": {"user_id": "123", "session_name": "test"},
         }
 
         json_str = json.dumps(snapshot)
@@ -72,14 +72,14 @@ class TestAgentTakeSnapshot:
         """Take snapshot of agent with no messages."""
         agent = Agent(model=MockedModelProvider([]))
 
-        snapshot = agent.take_snapshot()
+        snapshot = agent.take_snapshot(include="session")
 
         assert snapshot["type"] == "agent"
         assert snapshot["version"] == "1.0"
         assert "timestamp" in snapshot
-        assert snapshot["state"]["messages"] == []
-        assert snapshot["state"]["state"] == {}
-        assert snapshot["metadata"] == {}
+        assert snapshot["data"]["messages"] == []
+        assert snapshot["data"]["state"] == {}
+        assert snapshot["app_data"] == {}
 
     def test_take_snapshot_with_messages(self):
         """Take snapshot of agent with conversation history."""
@@ -88,55 +88,178 @@ class TestAgentTakeSnapshot:
         )
         agent("Hi")
 
-        snapshot = agent.take_snapshot()
+        snapshot = agent.take_snapshot(include="session")
 
-        assert len(snapshot["state"]["messages"]) == 2
-        assert snapshot["state"]["messages"][0]["content"][0]["text"] == "Hi"
-        assert snapshot["state"]["messages"][1]["content"][0]["text"] == "Hello!"
+        assert len(snapshot["data"]["messages"]) == 2
+        assert snapshot["data"]["messages"][0]["content"][0]["text"] == "Hi"
+        assert snapshot["data"]["messages"][1]["content"][0]["text"] == "Hello!"
 
     def test_take_snapshot_with_agent_state(self):
         """Take snapshot preserves agent state."""
         agent = Agent(model=MockedModelProvider([]), state={"counter": 42, "name": "test"})
 
-        snapshot = agent.take_snapshot()
+        snapshot = agent.take_snapshot(include="session")
 
-        assert snapshot["state"]["state"] == {"counter": 42, "name": "test"}
+        assert snapshot["data"]["state"] == {"counter": 42, "name": "test"}
 
-    def test_take_snapshot_with_metadata(self):
-        """Take snapshot with application-provided metadata."""
+    def test_take_snapshot_with_app_data(self):
+        """Take snapshot with application-provided app_data."""
         agent = Agent(model=MockedModelProvider([]))
 
-        snapshot = agent.take_snapshot(metadata={"user_id": "123", "session": "test"})
+        snapshot = agent.take_snapshot(include="session", app_data={"user_id": "123", "session": "test"})
 
-        assert snapshot["metadata"] == {"user_id": "123", "session": "test"}
+        assert snapshot["app_data"] == {"user_id": "123", "session": "test"}
 
     def test_take_snapshot_captures_conversation_manager_state(self):
         """Take snapshot captures conversation manager state."""
         agent = Agent(model=MockedModelProvider([]))
 
-        snapshot = agent.take_snapshot()
+        snapshot = agent.take_snapshot(include="session")
 
-        assert "conversation_manager_state" in snapshot["state"]
-        assert "__name__" in snapshot["state"]["conversation_manager_state"]
+        assert "conversation_manager_state" in snapshot["data"]
+        assert "__name__" in snapshot["data"]["conversation_manager_state"]
 
     def test_take_snapshot_captures_interrupt_state(self):
         """Take snapshot captures interrupt state."""
         agent = Agent(model=MockedModelProvider([]))
 
-        snapshot = agent.take_snapshot()
+        snapshot = agent.take_snapshot(include="session")
 
-        assert "interrupt_state" in snapshot["state"]
-        assert snapshot["state"]["interrupt_state"]["activated"] is False
+        assert "interrupt_state" in snapshot["data"]
+        assert snapshot["data"]["interrupt_state"]["activated"] is False
 
     def test_take_snapshot_timestamp_is_iso_format(self):
         """Verify timestamp is ISO 8601 format."""
         from datetime import datetime
 
         agent = Agent(model=MockedModelProvider([]))
-        snapshot = agent.take_snapshot()
+        snapshot = agent.take_snapshot(include="session")
 
         # Should not raise ValueError if valid ISO format
         datetime.fromisoformat(snapshot["timestamp"])
+
+
+class TestIncludeExcludeParameters:
+    """Tests for include/exclude parameter functionality."""
+
+    def test_include_session_preset(self):
+        """Session preset includes messages, state, conversation_manager_state, interrupt_state."""
+        agent = Agent(model=MockedModelProvider([]), state={"key": "value"}, system_prompt="Test prompt")
+
+        snapshot = agent.take_snapshot(include="session")
+
+        assert "messages" in snapshot["data"]
+        assert "state" in snapshot["data"]
+        assert "conversation_manager_state" in snapshot["data"]
+        assert "interrupt_state" in snapshot["data"]
+        assert "system_prompt" not in snapshot["data"]
+
+    def test_include_specific_fields(self):
+        """Include only specific fields."""
+        agent = Agent(model=MockedModelProvider([]), state={"key": "value"})
+
+        snapshot = agent.take_snapshot(include=["messages", "state"])
+
+        assert "messages" in snapshot["data"]
+        assert "state" in snapshot["data"]
+        assert "conversation_manager_state" not in snapshot["data"]
+        assert "interrupt_state" not in snapshot["data"]
+
+    def test_exclude_fields_from_session(self):
+        """Exclude specific fields from session preset."""
+        agent = Agent(model=MockedModelProvider([]))
+
+        snapshot = agent.take_snapshot(include="session", exclude=["interrupt_state"])
+
+        assert "messages" in snapshot["data"]
+        assert "state" in snapshot["data"]
+        assert "conversation_manager_state" in snapshot["data"]
+        assert "interrupt_state" not in snapshot["data"]
+
+    def test_exclude_only(self):
+        """Exclude fields from all available fields."""
+        agent = Agent(model=MockedModelProvider([]), system_prompt="Test")
+
+        snapshot = agent.take_snapshot(exclude=["system_prompt"])
+
+        assert "messages" in snapshot["data"]
+        assert "state" in snapshot["data"]
+        assert "system_prompt" not in snapshot["data"]
+
+    def test_include_system_prompt(self):
+        """Include system_prompt in snapshot."""
+        agent = Agent(model=MockedModelProvider([]), system_prompt="You are a helpful assistant.")
+
+        snapshot = agent.take_snapshot(include=["system_prompt"])
+
+        assert snapshot["data"]["system_prompt"] == "You are a helpful assistant."
+
+    def test_require_include_or_exclude(self):
+        """Raise error if neither include nor exclude is specified."""
+        agent = Agent(model=MockedModelProvider([]))
+
+        with pytest.raises(ValueError, match="Either 'include' or 'exclude' must be specified"):
+            agent.take_snapshot()
+
+    def test_invalid_include_field_raises(self):
+        """Invalid field names in include raise error."""
+        agent = Agent(model=MockedModelProvider([]))
+
+        with pytest.raises(ValueError, match="Invalid snapshot fields"):
+            agent.take_snapshot(include=["invalid_field"])
+
+    def test_invalid_exclude_field_raises(self):
+        """Invalid field names in exclude raise error."""
+        agent = Agent(model=MockedModelProvider([]))
+
+        with pytest.raises(ValueError, match="Invalid exclude fields"):
+            agent.take_snapshot(include="session", exclude=["invalid_field"])
+
+
+class TestSystemPromptSnapshot:
+    """Tests for system_prompt snapshotting."""
+
+    def test_system_prompt_captured_when_included(self):
+        """System prompt is captured when explicitly included."""
+        agent = Agent(model=MockedModelProvider([]), system_prompt="Be helpful")
+
+        snapshot = agent.take_snapshot(include=["system_prompt", "messages"])
+
+        assert snapshot["data"]["system_prompt"] == "Be helpful"
+
+    def test_system_prompt_restored_when_in_snapshot(self):
+        """System prompt is restored when present in snapshot."""
+        agent = Agent(model=MockedModelProvider([]), system_prompt="Original prompt")
+        snapshot: Snapshot = {
+            "type": "agent",
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "data": {
+                "system_prompt": "Restored prompt",
+            },
+            "app_data": {},
+        }
+
+        agent.load_snapshot(snapshot)
+
+        assert agent.system_prompt == "Restored prompt"
+
+    def test_system_prompt_not_modified_when_not_in_snapshot(self):
+        """System prompt is unchanged when not in snapshot."""
+        agent = Agent(model=MockedModelProvider([]), system_prompt="Original prompt")
+        snapshot: Snapshot = {
+            "type": "agent",
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "data": {
+                "messages": [],
+            },
+            "app_data": {},
+        }
+
+        agent.load_snapshot(snapshot)
+
+        assert agent.system_prompt == "Original prompt"
 
 
 class TestAgentLoadSnapshot:
@@ -149,7 +272,7 @@ class TestAgentLoadSnapshot:
             "type": "agent",
             "version": "1.0",
             "timestamp": "2024-01-01T00:00:00+00:00",
-            "state": {
+            "data": {
                 "messages": [{"role": "user", "content": [{"text": "Hello"}]}],
                 "state": {},
                 "conversation_manager_state": {
@@ -158,7 +281,7 @@ class TestAgentLoadSnapshot:
                 },
                 "interrupt_state": {"interrupts": {}, "context": {}, "activated": False},
             },
-            "metadata": {},
+            "app_data": {},
         }
 
         agent.load_snapshot(snapshot)
@@ -173,7 +296,7 @@ class TestAgentLoadSnapshot:
             "type": "agent",
             "version": "1.0",
             "timestamp": "2024-01-01T00:00:00+00:00",
-            "state": {
+            "data": {
                 "messages": [],
                 "state": {"counter": 42, "name": "restored"},
                 "conversation_manager_state": {
@@ -182,7 +305,7 @@ class TestAgentLoadSnapshot:
                 },
                 "interrupt_state": {"interrupts": {}, "context": {}, "activated": False},
             },
-            "metadata": {},
+            "app_data": {},
         }
 
         agent.load_snapshot(snapshot)
@@ -197,8 +320,8 @@ class TestAgentLoadSnapshot:
             "type": "multi-agent",
             "version": "1.0",
             "timestamp": "2024-01-01T00:00:00+00:00",
-            "state": {},
-            "metadata": {},
+            "data": {},
+            "app_data": {},
         }
 
         with pytest.raises(ValueError, match="snapshot type"):
@@ -217,7 +340,7 @@ class TestSnapshotRoundTrip:
         agent("First message")
 
         # Take snapshot at this point
-        snapshot = agent.take_snapshot(metadata={"checkpoint": "before_modification"})
+        snapshot = agent.take_snapshot(include="session", app_data={"checkpoint": "before_modification"})
 
         # Modify agent state
         agent.state.set("counter", 999)
@@ -264,7 +387,7 @@ class TestSnapshotRoundTrip:
         assert agent.state.get("counter") == 1
 
         # Take snapshot
-        snapshot = agent.take_snapshot()
+        snapshot = agent.take_snapshot(include="session")
 
         # Load into fresh agent
         agent2 = Agent(model=MockedModelProvider([]), tools=[increment_counter], state={"counter": 0})
@@ -284,7 +407,7 @@ class TestFileSystemPersister:
             messages=[{"role": "user", "content": [{"text": "Hello"}]}],
             state={"key": "value"},
         )
-        snapshot = agent.take_snapshot(metadata={"test": "persistence"})
+        snapshot = agent.take_snapshot(include="session", app_data={"test": "persistence"})
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             path = f.name
@@ -297,8 +420,8 @@ class TestFileSystemPersister:
 
             assert loaded["type"] == snapshot["type"]
             assert loaded["version"] == snapshot["version"]
-            assert loaded["state"] == snapshot["state"]
-            assert loaded["metadata"] == snapshot["metadata"]
+            assert loaded["data"] == snapshot["data"]
+            assert loaded["app_data"] == snapshot["app_data"]
         finally:
             Path(path).unlink(missing_ok=True)
 
@@ -312,7 +435,7 @@ class TestFileSystemPersister:
     def test_persister_creates_parent_directories(self):
         """Persister creates parent directories if they don't exist."""
         agent = Agent(model=MockedModelProvider([]))
-        snapshot = agent.take_snapshot()
+        snapshot = agent.take_snapshot(include="session")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "subdir" / "nested" / "snapshot.json"
@@ -325,33 +448,33 @@ class TestFileSystemPersister:
             assert loaded["type"] == snapshot["type"]
 
 
-class TestMetadataPreservation:
-    """Tests for application metadata preservation."""
+class TestAppDataPreservation:
+    """Tests for application app_data preservation."""
 
-    def test_metadata_not_modified_by_strands(self):
-        """Verify Strands does not modify application metadata."""
-        original_metadata = {
+    def test_app_data_not_modified_by_strands(self):
+        """Verify Strands does not modify application app_data."""
+        original_app_data = {
             "user_id": "user_123",
             "session_name": "test_session",
             "custom_data": {"nested": "value", "list": [1, 2, 3]},
         }
 
         agent = Agent(model=MockedModelProvider([]))
-        snapshot = agent.take_snapshot(metadata=original_metadata)
+        snapshot = agent.take_snapshot(include="session", app_data=original_app_data)
 
         # Load snapshot and take another
         agent.load_snapshot(snapshot)
-        # Metadata is not carried over on load - it's application-owned
+        # app_data is not carried over on load - it's application-owned
 
-        # Verify original metadata in snapshot is unchanged
-        assert snapshot["metadata"] == original_metadata
+        # Verify original app_data in snapshot is unchanged
+        assert snapshot["app_data"] == original_app_data
 
-    def test_metadata_survives_persistence(self):
-        """Verify metadata survives persistence round-trip."""
-        metadata = {"complex": {"nested": {"data": [1, 2, 3]}}}
+    def test_app_data_survives_persistence(self):
+        """Verify app_data survives persistence round-trip."""
+        app_data = {"complex": {"nested": {"data": [1, 2, 3]}}}
 
         agent = Agent(model=MockedModelProvider([]))
-        snapshot = agent.take_snapshot(metadata=metadata)
+        snapshot = agent.take_snapshot(include="session", app_data=app_data)
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             path = f.name
@@ -361,7 +484,7 @@ class TestMetadataPreservation:
             persister.save(snapshot)
             loaded = persister.load()
 
-            assert loaded["metadata"] == metadata
+            assert loaded["app_data"] == app_data
         finally:
             Path(path).unlink(missing_ok=True)
 
@@ -381,16 +504,16 @@ class TestSnapshotCreatedHook:
 
             def on_snapshot_created(self, event: SnapshotCreatedEvent) -> None:
                 hook_called.append(True)
-                event.snapshot["metadata"]["hook_added"] = "test_value"
+                event.snapshot["app_data"]["hook_added"] = "test_value"
 
         agent = Agent(model=MockedModelProvider([]), hooks=[TestHook()])
-        snapshot = agent.take_snapshot()
+        snapshot = agent.take_snapshot(include="session")
 
         assert len(hook_called) == 1
-        assert snapshot["metadata"]["hook_added"] == "test_value"
+        assert snapshot["app_data"]["hook_added"] == "test_value"
 
-    def test_hook_can_add_custom_data_to_metadata(self):
-        """Verify hooks can add custom data to snapshot metadata."""
+    def test_hook_can_add_custom_data_to_app_data(self):
+        """Verify hooks can add custom data to snapshot app_data."""
         from strands.hooks import HookProvider, HookRegistry, SnapshotCreatedEvent
 
         class CustomDataHook(HookProvider):
@@ -398,12 +521,12 @@ class TestSnapshotCreatedHook:
                 registry.add_callback(SnapshotCreatedEvent, self.on_snapshot_created)
 
             def on_snapshot_created(self, event: SnapshotCreatedEvent) -> None:
-                event.snapshot["metadata"]["custom_key"] = "custom_value"
-                event.snapshot["metadata"]["timestamp_added"] = "2024-01-01"
+                event.snapshot["app_data"]["custom_key"] = "custom_value"
+                event.snapshot["app_data"]["timestamp_added"] = "2024-01-01"
 
         agent = Agent(model=MockedModelProvider([]), hooks=[CustomDataHook()])
-        snapshot = agent.take_snapshot(metadata={"original": "data"})
+        snapshot = agent.take_snapshot(include="session", app_data={"original": "data"})
 
-        assert snapshot["metadata"]["original"] == "data"
-        assert snapshot["metadata"]["custom_key"] == "custom_value"
-        assert snapshot["metadata"]["timestamp_added"] == "2024-01-01"
+        assert snapshot["app_data"]["original"] == "data"
+        assert snapshot["app_data"]["custom_key"] == "custom_value"
+        assert snapshot["app_data"]["timestamp_added"] == "2024-01-01"

--- a/tests/strands/agent/test_snapshot.py
+++ b/tests/strands/agent/test_snapshot.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from strands import Agent, tool
-from strands.agent.snapshot import FileSystemPersister, Snapshot, Snapshotter
+from strands.agent.snapshot import FileSystemPersister, Snapshot, Snapshottable
 
 from ...fixtures.mocked_model_provider import MockedModelProvider
 
@@ -51,72 +51,28 @@ class TestSnapshotTypedDict:
         assert restored == snapshot
 
 
+class TestSnapshottableProtocol:
+    """Tests for Snapshottable protocol compliance."""
 
-class TestSnapshotter:
-    """Tests for Snapshotter class."""
-
-    def test_snapshotter_has_take_and_load(self):
-        """Verify Snapshotter has take and load methods."""
-        snapshotter = Snapshotter(include="session")
-
-        assert hasattr(snapshotter, "take")
-        assert hasattr(snapshotter, "load")
-        assert hasattr(snapshotter, "take_async")
-        assert callable(snapshotter.take)
-        assert callable(snapshotter.load)
-        assert callable(snapshotter.take_async)
-
-    def test_agent_has_snapshots_attribute(self):
-        """Verify Agent has snapshots attribute."""
+    def test_agent_is_snapshottable(self):
+        """Verify Agent implements Snapshottable protocol."""
         agent = Agent(model=MockedModelProvider([]))
 
-        assert hasattr(agent, "snapshots")
-        assert isinstance(agent.snapshots, Snapshotter)
-
-    def test_snapshotter_unbound_raises_on_take(self):
-        """Unbound snapshotter raises RuntimeError on take."""
-        snapshotter = Snapshotter(include="session")
-
-        with pytest.raises(RuntimeError, match="not bound to an agent"):
-            snapshotter.take()
-
-    def test_snapshotter_unbound_raises_on_load(self):
-        """Unbound snapshotter raises RuntimeError on load."""
-        snapshotter = Snapshotter(include="session")
-        snapshot: Snapshot = {
-            "type": "agent",
-            "version": "1.0",
-            "timestamp": "2024-01-01T00:00:00+00:00",
-            "data": {},
-            "app_data": {},
-        }
-
-        with pytest.raises(RuntimeError, match="not bound to an agent"):
-            snapshotter.load(snapshot)
-
-    def test_custom_snapshotter_passed_to_agent(self):
-        """Custom Snapshotter can be passed to Agent."""
-        snapshotter = Snapshotter(include="session", exclude=["interrupt_state"])
-        agent = Agent(model=MockedModelProvider([]), snapshots=snapshotter)
-
-        assert agent.snapshots is snapshotter
-
-    def test_default_snapshotter_created_if_not_provided(self):
-        """Default Snapshotter is created if not provided."""
-        agent = Agent(model=MockedModelProvider([]))
-
-        assert agent.snapshots is not None
-        assert isinstance(agent.snapshots, Snapshotter)
+        assert isinstance(agent, Snapshottable)
+        assert hasattr(agent, "take_snapshot")
+        assert hasattr(agent, "load_snapshot")
+        assert callable(agent.take_snapshot)
+        assert callable(agent.load_snapshot)
 
 
-class TestAgentSnapshotsTake:
-    """Tests for agent.snapshots.take() method."""
+class TestAgentTakeSnapshot:
+    """Tests for Agent.take_snapshot() method."""
 
     def test_take_snapshot_empty_agent(self):
         """Take snapshot of agent with no messages."""
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
+        agent = Agent(model=MockedModelProvider([]))
 
-        snapshot = agent.snapshots.take()
+        snapshot = agent.take_snapshot(include="session")
 
         assert snapshot["type"] == "agent"
         assert snapshot["version"] == "1.0"
@@ -129,11 +85,10 @@ class TestAgentSnapshotsTake:
         """Take snapshot of agent with conversation history."""
         agent = Agent(
             model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello!"}]}]),
-            snapshots=Snapshotter(include="session"),
         )
         agent("Hi")
 
-        snapshot = agent.snapshots.take()
+        snapshot = agent.take_snapshot(include="session")
 
         assert len(snapshot["data"]["messages"]) == 2
         assert snapshot["data"]["messages"][0]["content"][0]["text"] == "Hi"
@@ -141,38 +96,34 @@ class TestAgentSnapshotsTake:
 
     def test_take_snapshot_with_agent_state(self):
         """Take snapshot preserves agent state."""
-        agent = Agent(
-            model=MockedModelProvider([]),
-            state={"counter": 42, "name": "test"},
-            snapshots=Snapshotter(include="session"),
-        )
+        agent = Agent(model=MockedModelProvider([]), state={"counter": 42, "name": "test"})
 
-        snapshot = agent.snapshots.take()
+        snapshot = agent.take_snapshot(include="session")
 
         assert snapshot["data"]["state"] == {"counter": 42, "name": "test"}
 
     def test_take_snapshot_with_app_data(self):
         """Take snapshot with application-provided app_data."""
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
+        agent = Agent(model=MockedModelProvider([]))
 
-        snapshot = agent.snapshots.take(app_data={"user_id": "123", "session": "test"})
+        snapshot = agent.take_snapshot(include="session", app_data={"user_id": "123", "session": "test"})
 
         assert snapshot["app_data"] == {"user_id": "123", "session": "test"}
 
     def test_take_snapshot_captures_conversation_manager_state(self):
         """Take snapshot captures conversation manager state."""
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
+        agent = Agent(model=MockedModelProvider([]))
 
-        snapshot = agent.snapshots.take()
+        snapshot = agent.take_snapshot(include="session")
 
         assert "conversation_manager_state" in snapshot["data"]
         assert "__name__" in snapshot["data"]["conversation_manager_state"]
 
     def test_take_snapshot_captures_interrupt_state(self):
         """Take snapshot captures interrupt state."""
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
+        agent = Agent(model=MockedModelProvider([]))
 
-        snapshot = agent.snapshots.take()
+        snapshot = agent.take_snapshot(include="session")
 
         assert "interrupt_state" in snapshot["data"]
         assert snapshot["data"]["interrupt_state"]["activated"] is False
@@ -181,75 +132,11 @@ class TestAgentSnapshotsTake:
         """Verify timestamp is ISO 8601 format."""
         from datetime import datetime
 
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
-        snapshot = agent.snapshots.take()
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot = agent.take_snapshot(include="session")
 
         # Should not raise ValueError if valid ISO format
         datetime.fromisoformat(snapshot["timestamp"])
-
-
-
-class TestSnapshotterDefaults:
-    """Tests for Snapshotter default include/exclude behavior."""
-
-    def test_defaults_used_when_no_override(self):
-        """Snapshotter defaults are used when take() has no arguments."""
-        agent = Agent(
-            model=MockedModelProvider([]),
-            state={"key": "value"},
-            snapshots=Snapshotter(include="session"),
-        )
-
-        snapshot = agent.snapshots.take()
-
-        assert "messages" in snapshot["data"]
-        assert "state" in snapshot["data"]
-        assert "conversation_manager_state" in snapshot["data"]
-        assert "interrupt_state" in snapshot["data"]
-        assert "system_prompt" not in snapshot["data"]
-
-    def test_override_include_on_take(self):
-        """Override include on individual take() call."""
-        agent = Agent(
-            model=MockedModelProvider([]),
-            state={"key": "value"},
-            snapshots=Snapshotter(include="session"),
-        )
-
-        snapshot = agent.snapshots.take(include=["messages", "state"])
-
-        assert "messages" in snapshot["data"]
-        assert "state" in snapshot["data"]
-        assert "conversation_manager_state" not in snapshot["data"]
-        assert "interrupt_state" not in snapshot["data"]
-
-    def test_override_exclude_on_take(self):
-        """Override exclude on individual take() call."""
-        agent = Agent(
-            model=MockedModelProvider([]),
-            snapshots=Snapshotter(include="session"),
-        )
-
-        snapshot = agent.snapshots.take(exclude=["interrupt_state", "conversation_manager_state"])
-
-        assert "messages" in snapshot["data"]
-        assert "state" in snapshot["data"]
-        assert "conversation_manager_state" not in snapshot["data"]
-        assert "interrupt_state" not in snapshot["data"]
-
-    def test_default_exclude_applied(self):
-        """Default exclude is applied when no override."""
-        agent = Agent(
-            model=MockedModelProvider([]),
-            snapshots=Snapshotter(include="session", exclude=["interrupt_state"]),
-        )
-
-        snapshot = agent.snapshots.take()
-
-        assert "messages" in snapshot["data"]
-        assert "state" in snapshot["data"]
-        assert "conversation_manager_state" in snapshot["data"]
-        assert "interrupt_state" not in snapshot["data"]
 
 
 class TestIncludeExcludeParameters:
@@ -257,14 +144,9 @@ class TestIncludeExcludeParameters:
 
     def test_include_session_preset(self):
         """Session preset includes messages, state, conversation_manager_state, interrupt_state."""
-        agent = Agent(
-            model=MockedModelProvider([]),
-            state={"key": "value"},
-            system_prompt="Test prompt",
-            snapshots=Snapshotter(include="session"),
-        )
+        agent = Agent(model=MockedModelProvider([]), state={"key": "value"}, system_prompt="Test prompt")
 
-        snapshot = agent.snapshots.take()
+        snapshot = agent.take_snapshot(include="session")
 
         assert "messages" in snapshot["data"]
         assert "state" in snapshot["data"]
@@ -276,7 +158,7 @@ class TestIncludeExcludeParameters:
         """Include only specific fields."""
         agent = Agent(model=MockedModelProvider([]), state={"key": "value"})
 
-        snapshot = agent.snapshots.take(include=["messages", "state"])
+        snapshot = agent.take_snapshot(include=["messages", "state"])
 
         assert "messages" in snapshot["data"]
         assert "state" in snapshot["data"]
@@ -285,9 +167,9 @@ class TestIncludeExcludeParameters:
 
     def test_exclude_fields_from_session(self):
         """Exclude specific fields from session preset."""
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
+        agent = Agent(model=MockedModelProvider([]))
 
-        snapshot = agent.snapshots.take(exclude=["interrupt_state"])
+        snapshot = agent.take_snapshot(include="session", exclude=["interrupt_state"])
 
         assert "messages" in snapshot["data"]
         assert "state" in snapshot["data"]
@@ -298,7 +180,7 @@ class TestIncludeExcludeParameters:
         """Exclude fields from all available fields."""
         agent = Agent(model=MockedModelProvider([]), system_prompt="Test")
 
-        snapshot = agent.snapshots.take(exclude=["system_prompt"])
+        snapshot = agent.take_snapshot(exclude=["system_prompt"])
 
         assert "messages" in snapshot["data"]
         assert "state" in snapshot["data"]
@@ -308,7 +190,7 @@ class TestIncludeExcludeParameters:
         """Include system_prompt in snapshot."""
         agent = Agent(model=MockedModelProvider([]), system_prompt="You are a helpful assistant.")
 
-        snapshot = agent.snapshots.take(include=["system_prompt"])
+        snapshot = agent.take_snapshot(include=["system_prompt"])
 
         assert snapshot["data"]["system_prompt"] == "You are a helpful assistant."
 
@@ -317,22 +199,21 @@ class TestIncludeExcludeParameters:
         agent = Agent(model=MockedModelProvider([]))
 
         with pytest.raises(ValueError, match="Either 'include' or 'exclude' must be specified"):
-            agent.snapshots.take()
+            agent.take_snapshot()
 
     def test_invalid_include_field_raises(self):
         """Invalid field names in include raise error."""
         agent = Agent(model=MockedModelProvider([]))
 
         with pytest.raises(ValueError, match="Invalid snapshot fields"):
-            agent.snapshots.take(include=["invalid_field"])
+            agent.take_snapshot(include=["invalid_field"])
 
     def test_invalid_exclude_field_raises(self):
         """Invalid field names in exclude raise error."""
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
+        agent = Agent(model=MockedModelProvider([]))
 
         with pytest.raises(ValueError, match="Invalid exclude fields"):
-            agent.snapshots.take(exclude=["invalid_field"])
-
+            agent.take_snapshot(include="session", exclude=["invalid_field"])
 
 
 class TestSystemPromptSnapshot:
@@ -342,7 +223,7 @@ class TestSystemPromptSnapshot:
         """System prompt is captured when explicitly included."""
         agent = Agent(model=MockedModelProvider([]), system_prompt="Be helpful")
 
-        snapshot = agent.snapshots.take(include=["system_prompt", "messages"])
+        snapshot = agent.take_snapshot(include=["system_prompt", "messages"])
 
         assert snapshot["data"]["system_prompt"] == "Be helpful"
 
@@ -359,7 +240,7 @@ class TestSystemPromptSnapshot:
             "app_data": {},
         }
 
-        agent.snapshots.load(snapshot)
+        agent.load_snapshot(snapshot)
 
         assert agent.system_prompt == "Restored prompt"
 
@@ -376,13 +257,13 @@ class TestSystemPromptSnapshot:
             "app_data": {},
         }
 
-        agent.snapshots.load(snapshot)
+        agent.load_snapshot(snapshot)
 
         assert agent.system_prompt == "Original prompt"
 
 
-class TestAgentSnapshotsLoad:
-    """Tests for agent.snapshots.load() method."""
+class TestAgentLoadSnapshot:
+    """Tests for Agent.load_snapshot() method."""
 
     def test_load_snapshot_restores_messages(self):
         """Load snapshot restores message history."""
@@ -403,7 +284,7 @@ class TestAgentSnapshotsLoad:
             "app_data": {},
         }
 
-        agent.snapshots.load(snapshot)
+        agent.load_snapshot(snapshot)
 
         assert len(agent.messages) == 1
         assert agent.messages[0]["content"][0]["text"] == "Hello"
@@ -427,7 +308,7 @@ class TestAgentSnapshotsLoad:
             "app_data": {},
         }
 
-        agent.snapshots.load(snapshot)
+        agent.load_snapshot(snapshot)
 
         assert agent.state.get("counter") == 42
         assert agent.state.get("name") == "restored"
@@ -444,8 +325,7 @@ class TestAgentSnapshotsLoad:
         }
 
         with pytest.raises(ValueError, match="snapshot type"):
-            agent.snapshots.load(snapshot)
-
+            agent.load_snapshot(snapshot)
 
 
 class TestSnapshotRoundTrip:
@@ -456,12 +336,11 @@ class TestSnapshotRoundTrip:
         agent = Agent(
             model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Response 1"}]}]),
             state={"counter": 1},
-            snapshots=Snapshotter(include="session"),
         )
         agent("First message")
 
         # Take snapshot at this point
-        snapshot = agent.snapshots.take(app_data={"checkpoint": "before_modification"})
+        snapshot = agent.take_snapshot(include="session", app_data={"checkpoint": "before_modification"})
 
         # Modify agent state
         agent.state.set("counter", 999)
@@ -472,7 +351,7 @@ class TestSnapshotRoundTrip:
         assert len(agent.messages) == 3
 
         # Load snapshot to restore original state
-        agent.snapshots.load(snapshot)
+        agent.load_snapshot(snapshot)
 
         # Verify original state is restored
         assert agent.state.get("counter") == 1
@@ -499,7 +378,6 @@ class TestSnapshotRoundTrip:
             ),
             tools=[increment_counter],
             state={"counter": 0},
-            snapshots=Snapshotter(include="session"),
         )
 
         # Invoke agent to trigger tool
@@ -509,16 +387,11 @@ class TestSnapshotRoundTrip:
         assert agent.state.get("counter") == 1
 
         # Take snapshot
-        snapshot = agent.snapshots.take()
+        snapshot = agent.take_snapshot(include="session")
 
         # Load into fresh agent
-        agent2 = Agent(
-            model=MockedModelProvider([]),
-            tools=[increment_counter],
-            state={"counter": 0},
-            snapshots=Snapshotter(include="session"),
-        )
-        agent2.snapshots.load(snapshot)
+        agent2 = Agent(model=MockedModelProvider([]), tools=[increment_counter], state={"counter": 0})
+        agent2.load_snapshot(snapshot)
 
         assert agent2.state.get("counter") == 1
         assert len(agent2.messages) == len(agent.messages)
@@ -533,9 +406,8 @@ class TestFileSystemPersister:
             model=MockedModelProvider([]),
             messages=[{"role": "user", "content": [{"text": "Hello"}]}],
             state={"key": "value"},
-            snapshots=Snapshotter(include="session"),
         )
-        snapshot = agent.snapshots.take(app_data={"test": "persistence"})
+        snapshot = agent.take_snapshot(include="session", app_data={"test": "persistence"})
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             path = f.name
@@ -562,8 +434,8 @@ class TestFileSystemPersister:
 
     def test_persister_creates_parent_directories(self):
         """Persister creates parent directories if they don't exist."""
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
-        snapshot = agent.snapshots.take()
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot = agent.take_snapshot(include="session")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "subdir" / "nested" / "snapshot.json"
@@ -574,7 +446,6 @@ class TestFileSystemPersister:
             assert path.exists()
             loaded = persister.load()
             assert loaded["type"] == snapshot["type"]
-
 
 
 class TestAppDataPreservation:
@@ -588,11 +459,11 @@ class TestAppDataPreservation:
             "custom_data": {"nested": "value", "list": [1, 2, 3]},
         }
 
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
-        snapshot = agent.snapshots.take(app_data=original_app_data)
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot = agent.take_snapshot(include="session", app_data=original_app_data)
 
         # Load snapshot and take another
-        agent.snapshots.load(snapshot)
+        agent.load_snapshot(snapshot)
         # app_data is not carried over on load - it's application-owned
 
         # Verify original app_data in snapshot is unchanged
@@ -602,8 +473,8 @@ class TestAppDataPreservation:
         """Verify app_data survives persistence round-trip."""
         app_data = {"complex": {"nested": {"data": [1, 2, 3]}}}
 
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
-        snapshot = agent.snapshots.take(app_data=app_data)
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot = agent.take_snapshot(include="session", app_data=app_data)
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             path = f.name
@@ -617,70 +488,3 @@ class TestAppDataPreservation:
         finally:
             Path(path).unlink(missing_ok=True)
 
-
-class TestSnapshotCreatedHook:
-    """Tests for SnapshotCreatedEvent hook."""
-
-    def test_snapshot_created_hook_is_fired(self):
-        """Verify SnapshotCreatedEvent hook is fired after taking snapshot."""
-        from strands.hooks import HookProvider, HookRegistry, SnapshotCreatedEvent
-
-        hook_called = []
-
-        class TestHook(HookProvider):
-            def register_hooks(self, registry: HookRegistry, **kwargs) -> None:
-                registry.add_callback(SnapshotCreatedEvent, self.on_snapshot_created)
-
-            def on_snapshot_created(self, event: SnapshotCreatedEvent) -> None:
-                hook_called.append(True)
-                event.snapshot["app_data"]["hook_added"] = "test_value"
-
-        agent = Agent(model=MockedModelProvider([]), hooks=[TestHook()], snapshots=Snapshotter(include="session"))
-        snapshot = agent.snapshots.take()
-
-        assert len(hook_called) == 1
-        assert snapshot["app_data"]["hook_added"] == "test_value"
-
-    def test_hook_can_add_custom_data_to_app_data(self):
-        """Verify hooks can add custom data to snapshot app_data."""
-        from strands.hooks import HookProvider, HookRegistry, SnapshotCreatedEvent
-
-        class CustomDataHook(HookProvider):
-            def register_hooks(self, registry: HookRegistry, **kwargs) -> None:
-                registry.add_callback(SnapshotCreatedEvent, self.on_snapshot_created)
-
-            def on_snapshot_created(self, event: SnapshotCreatedEvent) -> None:
-                event.snapshot["app_data"]["custom_key"] = "custom_value"
-                event.snapshot["app_data"]["timestamp_added"] = "2024-01-01"
-
-        agent = Agent(model=MockedModelProvider([]), hooks=[CustomDataHook()], snapshots=Snapshotter(include="session"))
-        snapshot = agent.snapshots.take(app_data={"original": "data"})
-
-        assert snapshot["app_data"]["original"] == "data"
-        assert snapshot["app_data"]["custom_key"] == "custom_value"
-        assert snapshot["app_data"]["timestamp_added"] == "2024-01-01"
-
-
-class TestTakeAsync:
-    """Tests for agent.snapshots.take_async() method."""
-
-    @pytest.mark.asyncio
-    async def test_take_async_returns_snapshot(self):
-        """take_async returns a valid snapshot."""
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
-
-        snapshot = await agent.snapshots.take_async()
-
-        assert snapshot["type"] == "agent"
-        assert snapshot["version"] == "1.0"
-        assert "timestamp" in snapshot
-
-    @pytest.mark.asyncio
-    async def test_take_async_with_override(self):
-        """take_async respects include/exclude overrides."""
-        agent = Agent(model=MockedModelProvider([]), snapshots=Snapshotter(include="session"))
-
-        snapshot = await agent.snapshots.take_async(include=["messages"])
-
-        assert "messages" in snapshot["data"]
-        assert "state" not in snapshot["data"]

--- a/tests/strands/agent/test_snapshot.py
+++ b/tests/strands/agent/test_snapshot.py
@@ -1,0 +1,366 @@
+"""Tests for Agent snapshot functionality.
+
+These tests validate the low-level snapshot API for capturing and restoring
+agent state at specific points in time.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from strands import Agent, tool
+from strands.agent.snapshot import FileSystemPersister, Snapshot, Snapshottable
+
+from ...fixtures.mocked_model_provider import MockedModelProvider
+
+
+class TestSnapshotTypedDict:
+    """Tests for Snapshot TypedDict structure."""
+
+    def test_snapshot_has_required_fields(self):
+        """Verify Snapshot TypedDict has all required fields."""
+        snapshot: Snapshot = {
+            "type": "agent",
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "state": {},
+            "metadata": {},
+        }
+
+        assert snapshot["type"] == "agent"
+        assert snapshot["version"] == "1.0"
+        assert snapshot["timestamp"] == "2024-01-01T00:00:00+00:00"
+        assert snapshot["state"] == {}
+        assert snapshot["metadata"] == {}
+
+    def test_snapshot_is_json_serializable(self):
+        """Verify Snapshot can be serialized to JSON."""
+        snapshot: Snapshot = {
+            "type": "agent",
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "state": {"messages": [], "agent_state": {"key": "value"}},
+            "metadata": {"user_id": "123", "session_name": "test"},
+        }
+
+        json_str = json.dumps(snapshot)
+        restored = json.loads(json_str)
+
+        assert restored == snapshot
+
+
+class TestSnapshottableProtocol:
+    """Tests for Snapshottable protocol compliance."""
+
+    def test_agent_is_snapshottable(self):
+        """Verify Agent implements Snapshottable protocol."""
+        agent = Agent(model=MockedModelProvider([]))
+
+        assert isinstance(agent, Snapshottable)
+        assert hasattr(agent, "take_snapshot")
+        assert hasattr(agent, "load_snapshot")
+        assert callable(agent.take_snapshot)
+        assert callable(agent.load_snapshot)
+
+
+class TestAgentTakeSnapshot:
+    """Tests for Agent.take_snapshot() method."""
+
+    def test_take_snapshot_empty_agent(self):
+        """Take snapshot of agent with no messages."""
+        agent = Agent(model=MockedModelProvider([]))
+
+        snapshot = agent.take_snapshot()
+
+        assert snapshot["type"] == "agent"
+        assert snapshot["version"] == "1.0"
+        assert "timestamp" in snapshot
+        assert snapshot["state"]["messages"] == []
+        assert snapshot["state"]["agent_state"] == {}
+        assert snapshot["metadata"] == {}
+
+    def test_take_snapshot_with_messages(self):
+        """Take snapshot of agent with conversation history."""
+        agent = Agent(
+            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello!"}]}]),
+        )
+        agent("Hi")
+
+        snapshot = agent.take_snapshot()
+
+        assert len(snapshot["state"]["messages"]) == 2
+        assert snapshot["state"]["messages"][0]["content"][0]["text"] == "Hi"
+        assert snapshot["state"]["messages"][1]["content"][0]["text"] == "Hello!"
+
+    def test_take_snapshot_with_agent_state(self):
+        """Take snapshot preserves agent state."""
+        agent = Agent(model=MockedModelProvider([]), state={"counter": 42, "name": "test"})
+
+        snapshot = agent.take_snapshot()
+
+        assert snapshot["state"]["agent_state"] == {"counter": 42, "name": "test"}
+
+    def test_take_snapshot_with_metadata(self):
+        """Take snapshot with application-provided metadata."""
+        agent = Agent(model=MockedModelProvider([]))
+
+        snapshot = agent.take_snapshot(metadata={"user_id": "123", "session": "test"})
+
+        assert snapshot["metadata"] == {"user_id": "123", "session": "test"}
+
+    def test_take_snapshot_captures_conversation_manager_state(self):
+        """Take snapshot captures conversation manager state."""
+        agent = Agent(model=MockedModelProvider([]))
+
+        snapshot = agent.take_snapshot()
+
+        assert "conversation_manager_state" in snapshot["state"]
+        assert "__name__" in snapshot["state"]["conversation_manager_state"]
+
+    def test_take_snapshot_captures_interrupt_state(self):
+        """Take snapshot captures interrupt state."""
+        agent = Agent(model=MockedModelProvider([]))
+
+        snapshot = agent.take_snapshot()
+
+        assert "interrupt_state" in snapshot["state"]
+        assert snapshot["state"]["interrupt_state"]["activated"] is False
+
+    def test_take_snapshot_timestamp_is_iso_format(self):
+        """Verify timestamp is ISO 8601 format."""
+        from datetime import datetime
+
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot = agent.take_snapshot()
+
+        # Should not raise ValueError if valid ISO format
+        datetime.fromisoformat(snapshot["timestamp"])
+
+
+class TestAgentLoadSnapshot:
+    """Tests for Agent.load_snapshot() method."""
+
+    def test_load_snapshot_restores_messages(self):
+        """Load snapshot restores message history."""
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot: Snapshot = {
+            "type": "agent",
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "state": {
+                "messages": [{"role": "user", "content": [{"text": "Hello"}]}],
+                "agent_state": {},
+                "conversation_manager_state": {
+                    "__name__": "SlidingWindowConversationManager",
+                    "removed_message_count": 0,
+                },
+                "interrupt_state": {"interrupts": {}, "context": {}, "activated": False},
+            },
+            "metadata": {},
+        }
+
+        agent.load_snapshot(snapshot)
+
+        assert len(agent.messages) == 1
+        assert agent.messages[0]["content"][0]["text"] == "Hello"
+
+    def test_load_snapshot_restores_agent_state(self):
+        """Load snapshot restores agent state."""
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot: Snapshot = {
+            "type": "agent",
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "state": {
+                "messages": [],
+                "agent_state": {"counter": 42, "name": "restored"},
+                "conversation_manager_state": {
+                    "__name__": "SlidingWindowConversationManager",
+                    "removed_message_count": 0,
+                },
+                "interrupt_state": {"interrupts": {}, "context": {}, "activated": False},
+            },
+            "metadata": {},
+        }
+
+        agent.load_snapshot(snapshot)
+
+        assert agent.state.get("counter") == 42
+        assert agent.state.get("name") == "restored"
+
+    def test_load_snapshot_raises_on_type_mismatch(self):
+        """Load snapshot raises error if snapshot type doesn't match."""
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot: Snapshot = {
+            "type": "multi-agent",
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "state": {},
+            "metadata": {},
+        }
+
+        with pytest.raises(ValueError, match="snapshot type"):
+            agent.load_snapshot(snapshot)
+
+
+class TestSnapshotRoundTrip:
+    """Tests for complete snapshot round-trip scenarios."""
+
+    def test_round_trip_preserves_state(self):
+        """Take snapshot, modify agent, load snapshot restores original state."""
+        agent = Agent(
+            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Response 1"}]}]),
+            state={"counter": 1},
+        )
+        agent("First message")
+
+        # Take snapshot at this point
+        snapshot = agent.take_snapshot(metadata={"checkpoint": "before_modification"})
+
+        # Modify agent state
+        agent.state.set("counter", 999)
+        agent.messages.append({"role": "user", "content": [{"text": "Second message"}]})
+
+        # Verify state was modified
+        assert agent.state.get("counter") == 999
+        assert len(agent.messages) == 3
+
+        # Load snapshot to restore original state
+        agent.load_snapshot(snapshot)
+
+        # Verify original state is restored
+        assert agent.state.get("counter") == 1
+        assert len(agent.messages) == 2
+
+    def test_round_trip_with_tool_calls(self):
+        """Snapshot preserves state across tool invocations."""
+
+        @tool
+        def increment_counter(agent: Agent):
+            """Increment the counter in agent state."""
+            current = agent.state.get("counter") or 0
+            agent.state.set("counter", current + 1)
+
+        agent = Agent(
+            model=MockedModelProvider(
+                [
+                    {
+                        "role": "assistant",
+                        "content": [{"toolUse": {"name": "increment_counter", "toolUseId": "1", "input": {}}}],
+                    },
+                    {"role": "assistant", "content": [{"text": "Counter incremented"}]},
+                ]
+            ),
+            tools=[increment_counter],
+            state={"counter": 0},
+        )
+
+        # Invoke agent to trigger tool
+        agent("Increment counter")
+
+        # Verify tool was called
+        assert agent.state.get("counter") == 1
+
+        # Take snapshot
+        snapshot = agent.take_snapshot()
+
+        # Load into fresh agent
+        agent2 = Agent(model=MockedModelProvider([]), tools=[increment_counter], state={"counter": 0})
+        agent2.load_snapshot(snapshot)
+
+        assert agent2.state.get("counter") == 1
+        assert len(agent2.messages) == len(agent.messages)
+
+
+class TestFileSystemPersister:
+    """Tests for FileSystemPersister persistence helper."""
+
+    def test_save_and_load_snapshot(self):
+        """Save snapshot to file and load it back."""
+        agent = Agent(
+            model=MockedModelProvider([]),
+            messages=[{"role": "user", "content": [{"text": "Hello"}]}],
+            state={"key": "value"},
+        )
+        snapshot = agent.take_snapshot(metadata={"test": "persistence"})
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            path = f.name
+
+        try:
+            persister = FileSystemPersister(path=path)
+            persister.save(snapshot)
+
+            loaded = persister.load()
+
+            assert loaded["type"] == snapshot["type"]
+            assert loaded["version"] == snapshot["version"]
+            assert loaded["state"] == snapshot["state"]
+            assert loaded["metadata"] == snapshot["metadata"]
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_load_nonexistent_file_raises(self):
+        """Loading from nonexistent file raises error."""
+        persister = FileSystemPersister(path="/nonexistent/path/snapshot.json")
+
+        with pytest.raises(FileNotFoundError):
+            persister.load()
+
+    def test_persister_creates_parent_directories(self):
+        """Persister creates parent directories if they don't exist."""
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot = agent.take_snapshot()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "subdir" / "nested" / "snapshot.json"
+            persister = FileSystemPersister(path=str(path))
+
+            persister.save(snapshot)
+
+            assert path.exists()
+            loaded = persister.load()
+            assert loaded["type"] == snapshot["type"]
+
+
+class TestMetadataPreservation:
+    """Tests for application metadata preservation."""
+
+    def test_metadata_not_modified_by_strands(self):
+        """Verify Strands does not modify application metadata."""
+        original_metadata = {
+            "user_id": "user_123",
+            "session_name": "test_session",
+            "custom_data": {"nested": "value", "list": [1, 2, 3]},
+        }
+
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot = agent.take_snapshot(metadata=original_metadata)
+
+        # Load snapshot and take another
+        agent.load_snapshot(snapshot)
+        # Metadata is not carried over on load - it's application-owned
+
+        # Verify original metadata in snapshot is unchanged
+        assert snapshot["metadata"] == original_metadata
+
+    def test_metadata_survives_persistence(self):
+        """Verify metadata survives persistence round-trip."""
+        metadata = {"complex": {"nested": {"data": [1, 2, 3]}}}
+
+        agent = Agent(model=MockedModelProvider([]))
+        snapshot = agent.take_snapshot(metadata=metadata)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            path = f.name
+
+        try:
+            persister = FileSystemPersister(path=path)
+            persister.save(snapshot)
+            loaded = persister.load()
+
+            assert loaded["metadata"] == metadata
+        finally:
+            Path(path).unlink(missing_ok=True)


### PR DESCRIPTION
## Motivation

Developers need explicit control over agent state snapshots for advanced context management strategies. The existing `SessionManager` works incrementally, recording messages as they happen. The snapshot API provides a different capability:

- **Point-in-time capture**: Save complete agent state at any moment
- **Arbitrary restore**: Restore to any previously captured state
- **Context management**: Enable advanced strategies with state modifications

This enables use cases like checkpointing before risky operations, implementing undo/redo functionality, and creating branching conversation flows.

Resolves #29

## Public API Changes

New `Snapshot` TypedDict and `Snapshottable` protocol in `strands.agent.snapshot`:

```python
# Take a snapshot with session preset (messages, state, conversation_manager_state, interrupt_state)
snapshot = agent.take_snapshot(include="session", app_data={"user_id": "123"})

# Take a snapshot with specific fields only
snapshot = agent.take_snapshot(include=["messages", "state"])

# Exclude specific fields from session preset
snapshot = agent.take_snapshot(include="session", exclude=["interrupt_state"])

# Include system_prompt in snapshot
snapshot = agent.take_snapshot(include=["messages", "state", "system_prompt"])

# Later, restore the agent to that point in time
agent.load_snapshot(snapshot)

# Persist to filesystem
from strands.agent import FileSystemPersister

persister = FileSystemPersister(path="checkpoints/snapshot.json")
persister.save(snapshot)
loaded_snapshot = persister.load()
```

### Snapshot Fields
Available fields for `include`/`exclude`:
- `messages`: Conversation history
- `state`: Custom application state (`agent.state`)
- `conversation_manager_state`: Internal state of the conversation manager
- `interrupt_state`: State of any active interrupts
- `system_prompt`: The agent's system prompt

### Named Presets
- `"session"`: Includes messages, state, conversation_manager_state, interrupt_state (excludes system_prompt)

### SnapshotCreatedEvent Hook

A new `SnapshotCreatedEvent` is fired after `take_snapshot()` completes:

```python
from strands.hooks import HookProvider, HookRegistry, SnapshotCreatedEvent

class CustomDataHook(HookProvider):
    def register_hooks(self, registry: HookRegistry, **kwargs) -> None:
        registry.add_callback(SnapshotCreatedEvent, self.on_snapshot_created)

    def on_snapshot_created(self, event: SnapshotCreatedEvent) -> None:
        event.snapshot["app_data"]["custom_key"] = "custom_value"
```

## Use Cases

- **Checkpoint before risky operations**: Save state before potentially destructive agent actions
- **Undo/redo functionality**: Implement conversation branching and rollback
- **State transfer**: Move agent state between instances with compatible configurations
- **Testing and debugging**: Capture and replay specific agent states