### PR TITLE
feat(hooks): add ModelStreamChunkEvent for streaming observability

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -22,3 +22,38 @@ The hooks system enables extensible agent functionality through strongly-typed e
 ## Writable Properties
 
 Some events have writable properties that modify agent behavior. Values are re-read after callbacks complete. For example, `BeforeToolCallEvent.selected_tool` is writable - after invoking the callback, the modified `selected_tool` takes effect for the tool call.
+
+## Available Events
+
+### Model Streaming Events
+
+#### `ModelStreamChunkEvent`
+
+Fired for each raw streaming chunk received from the model during response generation. This event allows hook providers to observe streaming progress in real-time.
+
+**Attributes:**
+- `agent`: The agent instance that triggered this event
+- `chunk`: The raw streaming chunk (`StreamEvent`) from the model response
+
+**Use Cases:**
+- Logging streaming progress
+- Collecting metrics on streaming performance
+- Content filtering during streaming
+- Real-time monitoring of model output
+
+**Example:**
+```python
+from strands.hooks import HookProvider, HookRegistry
+from strands.hooks.events import ModelStreamChunkEvent
+
+class StreamingLogger(HookProvider):
+    def register_hooks(self, registry: HookRegistry) -> None:
+        registry.add_callback(ModelStreamChunkEvent, self.on_chunk)
+
+    def on_chunk(self, event: ModelStreamChunkEvent) -> None:
+        # Log each streaming chunk
+        if "contentBlockDelta" in event.chunk:
+            print(f"Received delta: {event.chunk}")
+
+agent = Agent(hooks=[StreamingLogger()])
+```

--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -337,6 +337,7 @@ async def _handle_model_execution(
                     tool_choice=structured_output_context.tool_choice,
                     invocation_state=invocation_state,
                     cancel_signal=agent._cancel_signal,
+                    agent=agent,
                 ):
                     yield event
 

--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -6,7 +6,7 @@ import threading
 import time
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..models.model import Model
 from ..tools import InvalidToolUseNameException
@@ -39,6 +39,11 @@ from ..types.streaming import (
     Usage,
 )
 from ..types.tools import ToolSpec, ToolUse
+
+if TYPE_CHECKING:
+    from ..agent import Agent
+    from ..hooks import HookRegistry
+    from ..hooks.events import ModelStreamChunkEvent as ModelStreamChunkHookEvent
 
 logger = logging.getLogger(__name__)
 
@@ -387,6 +392,7 @@ async def process_stream(
     chunks: AsyncIterable[StreamEvent],
     start_time: float | None = None,
     cancel_signal: threading.Event | None = None,
+    agent: "Agent | None" = None,
 ) -> AsyncGenerator[TypedEvent, None]:
     """Processes the response stream from the API, constructing the final message and extracting usage metrics.
 
@@ -394,10 +400,14 @@ async def process_stream(
         chunks: The chunks of the response stream from the model.
         start_time: Time when the model request is initiated
         cancel_signal: Optional threading.Event to check for cancellation during streaming.
+        agent: Optional agent instance to invoke ModelStreamChunkEvent hooks.
 
     Yields:
         The reason for stopping, the constructed message, and the usage metrics.
     """
+    # Import here to avoid circular imports
+    from ..hooks.events import ModelStreamChunkEvent as ModelStreamChunkHookEvent
+
     stop_reason: StopReason = "end_turn"
     first_byte_time = None
 
@@ -432,6 +442,10 @@ async def process_stream(
             first_byte_time = time.time()
         yield ModelStreamChunkEvent(chunk=chunk)
 
+        # Invoke hook for streaming chunk if agent is provided
+        if agent is not None:
+            await agent.hooks.invoke_callbacks_async(ModelStreamChunkHookEvent(agent=agent, chunk=chunk))
+
         if "messageStart" in chunk:
             state["message"] = handle_message_start(chunk["messageStart"], state["message"])
         elif "contentBlockStart" in chunk:
@@ -464,6 +478,7 @@ async def stream_messages(
     system_prompt_content: list[SystemContentBlock] | None = None,
     invocation_state: dict[str, Any] | None = None,
     cancel_signal: threading.Event | None = None,
+    agent: "Agent | None" = None,
     **kwargs: Any,
 ) -> AsyncGenerator[TypedEvent, None]:
     """Streams messages to the model and processes the response.
@@ -478,6 +493,7 @@ async def stream_messages(
             system prompt data.
         invocation_state: Caller-provided state/context that was passed to the agent when it was invoked.
         cancel_signal: Optional threading.Event to check for cancellation during streaming.
+        agent: Optional agent instance to invoke ModelStreamChunkEvent hooks.
         **kwargs: Additional keyword arguments for future extensibility.
 
     Yields:
@@ -497,5 +513,5 @@ async def stream_messages(
         invocation_state=invocation_state,
     )
 
-    async for event in process_stream(chunks, start_time, cancel_signal):
+    async for event in process_stream(chunks, start_time, cancel_signal, agent=agent):
         yield event

--- a/src/strands/hooks/__init__.py
+++ b/src/strands/hooks/__init__.py
@@ -43,6 +43,7 @@ from .events import (
     BeforeNodeCallEvent,
     BeforeToolCallEvent,
     MessageAddedEvent,
+    ModelStreamChunkEvent,
     MultiAgentInitializedEvent,
 )
 from .registry import BaseHookEvent, HookCallback, HookEvent, HookProvider, HookRegistry
@@ -56,6 +57,7 @@ __all__ = [
     "AfterModelCallEvent",
     "AfterInvocationEvent",
     "MessageAddedEvent",
+    "ModelStreamChunkEvent",
     "HookEvent",
     "HookProvider",
     "HookCallback",

--- a/src/strands/hooks/events.py
+++ b/src/strands/hooks/events.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 from ..types.agent import AgentInput
 from ..types.content import Message, Messages
 from ..types.interrupt import _Interruptible
-from ..types.streaming import StopReason
+from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import AgentTool, ToolResult, ToolUse
 from .registry import BaseHookEvent, HookEvent
 
@@ -301,6 +301,21 @@ class AfterModelCallEvent(HookEvent):
     def should_reverse_callbacks(self) -> bool:
         """True to invoke callbacks in reverse order."""
         return True
+
+
+@dataclass
+class ModelStreamChunkEvent(HookEvent):
+    """Event triggered for each streaming chunk from the model.
+
+    This event is fired during model streaming for each chunk received,
+    allowing hook providers to observe streaming progress, implement
+    logging, collect metrics, or perform content filtering.
+
+    Attributes:
+        chunk: The raw streaming chunk from the model response.
+    """
+
+    chunk: StreamEvent
 
 
 # Multiagent hook events start here

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -1417,3 +1417,122 @@ async def test_process_stream_keeps_tool_use_stop_reason_unchanged(agenerator, a
     last_event = cast(ModelStopReason, (await alist(stream))[-1])
 
     assert last_event["stop"][0] == "tool_use"
+
+
+@pytest.mark.asyncio
+async def test_process_stream_invokes_model_stream_chunk_hook(agenerator, alist):
+    """Test that ModelStreamChunkEvent hook is invoked for each chunk."""
+    mock_agent = unittest.mock.MagicMock()
+    mock_hooks = unittest.mock.MagicMock()
+    mock_agent.hooks = mock_hooks
+
+    # Make invoke_callbacks_async return a coroutine
+    async def mock_invoke(*args, **kwargs):
+        pass
+
+    mock_hooks.invoke_callbacks_async = unittest.mock.AsyncMock(side_effect=mock_invoke)
+
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockDelta": {"delta": {"text": "Hello"}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 5, "outputTokens": 10, "totalTokens": 15},
+                "metrics": {"latencyMs": 50},
+            }
+        },
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response), agent=mock_agent)
+    await alist(stream)
+
+    # Verify hook was invoked for each chunk (5 chunks)
+    assert mock_hooks.invoke_callbacks_async.call_count == 5
+
+    # Verify each call was with ModelStreamChunkEvent containing correct agent and chunk
+    from strands.hooks.events import ModelStreamChunkEvent as ModelStreamChunkHookEvent
+
+    for i, call in enumerate(mock_hooks.invoke_callbacks_async.call_args_list):
+        event = call[0][0]
+        assert isinstance(event, ModelStreamChunkHookEvent)
+        assert event.agent is mock_agent
+        assert event.chunk == response[i]
+
+
+@pytest.mark.asyncio
+async def test_process_stream_without_agent_does_not_invoke_hook(agenerator, alist):
+    """Test that no hook is invoked when agent is not provided."""
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockDelta": {"delta": {"text": "Hello"}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+    ]
+
+    # This should not raise any errors when agent is None (default)
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+    events = await alist(stream)
+
+    # Verify we still get the expected events
+    assert len(events) > 0
+
+
+@pytest.mark.asyncio
+async def test_stream_messages_with_agent_invokes_hook(agenerator, alist):
+    """Test that stream_messages passes agent to process_stream for hook invocation."""
+    mock_model = unittest.mock.MagicMock()
+    mock_agent = unittest.mock.MagicMock()
+    mock_hooks = unittest.mock.MagicMock()
+    mock_agent.hooks = mock_hooks
+    mock_hooks.invoke_callbacks_async = unittest.mock.AsyncMock()
+
+    mock_model.stream.return_value = agenerator(
+        [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockDelta": {"delta": {"text": "test"}}},
+            {"contentBlockStop": {}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+    )
+
+    stream = strands.event_loop.streaming.stream_messages(
+        mock_model,
+        system_prompt_content=[{"text": "test prompt"}],
+        messages=[{"role": "user", "content": [{"text": "hello"}]}],
+        tool_specs=None,
+        system_prompt="test prompt",
+        agent=mock_agent,
+    )
+
+    await alist(stream)
+
+    # Verify hook was invoked for each chunk (4 chunks)
+    assert mock_hooks.invoke_callbacks_async.call_count == 4
+
+
+@pytest.mark.asyncio
+async def test_stream_messages_without_agent_works(agenerator, alist):
+    """Test that stream_messages works without agent parameter."""
+    mock_model = unittest.mock.MagicMock()
+    mock_model.stream.return_value = agenerator(
+        [
+            {"contentBlockDelta": {"delta": {"text": "test"}}},
+            {"contentBlockStop": {}},
+        ]
+    )
+
+    stream = strands.event_loop.streaming.stream_messages(
+        mock_model,
+        system_prompt_content=[{"text": "test prompt"}],
+        messages=[{"role": "user", "content": [{"text": "hello"}]}],
+        tool_specs=None,
+        system_prompt="test prompt",
+        # agent not provided - should default to None
+    )
+
+    events = await alist(stream)
+
+    # Verify we still get events
+    assert len(events) > 0

--- a/tests/strands/hooks/test_events.py
+++ b/tests/strands/hooks/test_events.py
@@ -10,6 +10,8 @@ from strands.hooks import (
     BaseHookEvent,
     BeforeMultiAgentInvocationEvent,
     BeforeNodeCallEvent,
+    HookEvent,
+    ModelStreamChunkEvent,
     MultiAgentInitializedEvent,
 )
 
@@ -18,6 +20,75 @@ from strands.hooks import (
 def orchestrator():
     """Mock orchestrator for testing."""
     return Mock()
+
+
+@pytest.fixture
+def mock_agent():
+    """Mock agent for testing."""
+    return Mock()
+
+
+def test_model_stream_chunk_event_creation(mock_agent):
+    """Test ModelStreamChunkEvent creation with agent and chunk."""
+    chunk = {"contentBlockDelta": {"delta": {"text": "Hello"}}}
+    event = ModelStreamChunkEvent(agent=mock_agent, chunk=chunk)
+
+    assert event.agent is mock_agent
+    assert event.chunk == chunk
+    assert isinstance(event, HookEvent)
+
+
+def test_model_stream_chunk_event_with_message_start(mock_agent):
+    """Test ModelStreamChunkEvent with messageStart chunk."""
+    chunk = {"messageStart": {"role": "assistant"}}
+    event = ModelStreamChunkEvent(agent=mock_agent, chunk=chunk)
+
+    assert event.agent is mock_agent
+    assert event.chunk == chunk
+
+
+def test_model_stream_chunk_event_with_metadata(mock_agent):
+    """Test ModelStreamChunkEvent with metadata chunk."""
+    chunk = {
+        "metadata": {
+            "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+            "metrics": {"latencyMs": 100},
+        }
+    }
+    event = ModelStreamChunkEvent(agent=mock_agent, chunk=chunk)
+
+    assert event.agent is mock_agent
+    assert event.chunk == chunk
+
+
+def test_model_stream_chunk_event_with_tool_use(mock_agent):
+    """Test ModelStreamChunkEvent with tool use chunk."""
+    chunk = {
+        "contentBlockStart": {
+            "start": {"toolUse": {"toolUseId": "123", "name": "test_tool"}}
+        }
+    }
+    event = ModelStreamChunkEvent(agent=mock_agent, chunk=chunk)
+
+    assert event.agent is mock_agent
+    assert event.chunk == chunk
+
+
+def test_model_stream_chunk_event_should_not_reverse_callbacks(mock_agent):
+    """Test that ModelStreamChunkEvent does not reverse callbacks."""
+    chunk = {"contentBlockDelta": {"delta": {"text": "test"}}}
+    event = ModelStreamChunkEvent(agent=mock_agent, chunk=chunk)
+
+    assert event.should_reverse_callbacks is False
+
+
+def test_model_stream_chunk_event_chunk_not_writable(mock_agent):
+    """Test that chunk property is not writable."""
+    chunk = {"contentBlockDelta": {"delta": {"text": "test"}}}
+    event = ModelStreamChunkEvent(agent=mock_agent, chunk=chunk)
+
+    with pytest.raises(AttributeError):
+        event.chunk = {"different": "chunk"}
 
 
 def test_multi_agent_initialization_event_with_orchestrator_only(orchestrator):


### PR DESCRIPTION
## Motivation

Hook providers often need to observe or act on streaming data from the model in real-time. Currently, there's no way for hooks to access individual streaming chunks - they can only observe events before and after the complete model call. This limits use cases like:

- Real-time streaming progress logging
- Token counting during streaming
- Content filtering as tokens arrive
- Custom streaming UI indicators

This feature achieves parity with the TypeScript SDK's `ModelStreamUpdateEvent`.

Resolves #32

## Public API Changes

`ModelStreamChunkEvent` is now available for hook providers to observe streaming chunks:

```python
from strands.hooks import HookProvider, HookRegistry
from strands.hooks.events import ModelStreamChunkEvent

class StreamingLogger(HookProvider):
    def register_hooks(self, registry: HookRegistry) -> None:
        registry.add_callback(ModelStreamChunkEvent, self.on_chunk)

    def on_chunk(self, event: ModelStreamChunkEvent) -> None:
        # Log each streaming chunk
        if "contentBlockDelta" in event.chunk:
            print(f"Received delta: {event.chunk}")

# Use with agent
agent = Agent(hooks=[StreamingLogger()])
```

The event includes:
- `agent`: Reference to the agent instance (inherited from `HookEvent`)
- `chunk`: The raw `StreamEvent` from the model response

The hook fires for ALL streaming chunks (including metadata, message start/stop) AFTER yielding the internal `TypedEvent`, maintaining existing consumer behavior.

## Use Cases

- **Streaming logging**: Log each chunk as it arrives for debugging or monitoring
- **Token metrics**: Count tokens or track streaming performance in real-time
- **Content filtering**: Inspect streaming content for moderation purposes
- **Progress indicators**: Build custom UI showing streaming progress