### PR TITLE
test: verify smart doc preview links

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -3,7 +3,7 @@ title: Snapshots
 description: "Capture and restore agent state at any point in time. Use snapshots for checkpointing, undo/redo, branching conversations, and custom persistence."
 ---
 
-Snapshots capture agent state at a point in time so you can save and restore it later. You choose which fields to include — either by picking a preset (a preconfigured set of fields) or by specifying fields directly — and you can further refine with includes and excludes. Snapshots are plain JSON-serializable objects — persistence is up to you.
+Snapshots capture agent state at a point in time so you can save and restore it later. You choose which fields to include — either by picking a preset (a preconfigured set of fields) or by specifying fields directly — and you can further refine with includes and excludes. Snapshots are plain, JSON-serializable objects — persistence is up to you.
 
 ## Basic Usage
 

--- a/site/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -6,7 +6,7 @@ sidebar:
 tags: [tool-authoring, mcp]
 ---
 
-Tools are the primary mechanism for extending agent capabilities, enabling them to perform actions beyond simple text generation. Tools allow agents to interact with external systems, access data, and manipulate their environment.
+Tools are the primary mechanism for extending agent capabilities, enabling them to perform actions beyond text generation. Tools allow agents to interact with external systems, access data, and manipulate their environment.
 
 Strands Agents Tools is a community-driven project that provides a powerful set of tools for your agents to use. For more information, see [Strands Agents Tools](community-tools-package.md).
 


### PR DESCRIPTION
## Summary
Test PR to verify the smart preview link workflow generates correct URLs.

**Changed files:**
- `site/src/content/docs/user-guide/concepts/tools/index.mdx` (index file → should link to `/docs/user-guide/concepts/tools/`)
- `site/src/content/docs/user-guide/concepts/agents/snapshots.mdx` (regular file → should link to `/docs/user-guide/concepts/agents/snapshots/`)

## Expected behavior
The bot comment should list two preview links:
- `user-guide/concepts/tools` (not `user-guide/concepts/tools/index`)
- `user-guide/concepts/agents/snapshots`